### PR TITLE
(feat) implemented the ability to pass render_data a stream to write to

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,12 @@ pub use parser::Parser;
 #[test]
 fn basic_end_to_end_test() {
     use std::collections::hashmap::HashMap;
+    use std::io::MemWriter;
+    use std::str;
 
+    let mut mem_wr = MemWriter::new();
     let mut data_map: HashMap<&str, &str> = HashMap::new();
+
     data_map.insert("value1", "Bob");
     data_map.insert("value2", "Tom");
     data_map.insert("value3", "Joe");
@@ -24,7 +28,15 @@ fn basic_end_to_end_test() {
     let tags = Parser::tag_lines(in_data);
     let tokens = Parser::create_token_map_from_tags(&tags);
     let data = Build::create_data_map(tokens, data_map);
-    let output = Template::render_data(data, &tags);
+
+    // write to memwriter stream
+    Template::render_data(&mut mem_wr, data, &tags);
+
+    // unwrap bytes
+    let output_bytes = mem_wr.unwrap();
+
+    // bytes to string
+    let output = str::from_utf8(output_bytes.as_slice()).unwrap().to_string();
 
     // Template::write_to_mem(output.as_slice(), out_path);
     let mut expected: String = String::new();

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,5 +1,5 @@
 use std::collections::hashmap::HashMap;
-use std::io::{File};
+use std::io::{BufferedWriter, File};
 use parser::{Node, Tag};
 
 pub struct Template<'a>;
@@ -9,17 +9,15 @@ impl<'a> Template<'a> {
         Template
     }
 
-    pub fn render_data<'a>(data: HashMap<&'a str, &'a str>, nodes: &'a Vec<Node>) -> String {
+    pub fn render_data<'a, W: Writer>(writer: &mut W,  data: HashMap<&'a str, &'a str>, nodes: &'a Vec<Node>) {
         let mut output = String::new();
         for node in nodes.iter() {
             if !data.contains_key(&node.val.as_slice()) {
-                output = output.append(node.val.as_slice());
+                writer.write_str(node.val.as_slice());
             } else {
-                output = output.append(data[node.val.as_slice()]);
+                writer.write_str(data[node.val.as_slice()]);
             }
         }
-
-        output
     }
 
     pub fn write_to_mem(data: &str, path: &str) {


### PR DESCRIPTION
Implemented the ability to pass `Template::render_data` a stream to write to. Existing test passes using `MemWriter` and stringifying the bytes:

![image](https://cloud.githubusercontent.com/assets/2935356/4352913/49d0560e-422c-11e4-97dd-994e8cab6a8d.png)
![image](https://cloud.githubusercontent.com/assets/2935356/4352903/37c18050-422c-11e4-9f03-6c5aaa58a1bc.png)
