### PR TITLE
Update travis build rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,31 @@
-language: rust
-script:
-  - cargo test
 sudo: false
+language: rust
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+rust:
+  - nightly
+  - beta
+  - stable
+  - 1.3.0
+matrix:
+  allow_failures:
+    - rust: nightly
+before_script:
+  - |
+      pip install 'travis-cargo<0.2' --user &&
+      export PATH=$HOME/.local/bin:$PATH
+script:
+  - |
+      travis-cargo build &&
+      travis-cargo test &&
+      travis-cargo bench &&
+      travis-cargo --only stable doc
+after_success:
+  - travis-cargo --only stable doc-upload
+env:
+  global:
+    secure: FILL_ME_IN

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ authors = ["Jarrod Ruhland <jarrod.ruhland@gmail.com>",
 
 description = "Mustache templating engine for rust"
 license = "MIT"
+documentation = "https://rustache.github.io/rustache/"
+repository = "https://github.com/rustache/rustache.git"
 
 [lib]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Rustache [![Build Status](https://travis-ci.org/rustache/rustache.svg?branch=master)](https://travis-ci.org/rustache/rustache)
 ====
 
-[Rustache](https://rustache.github.io) is a [Rust](https://www.rust-lang.org/) implementation of the [Mustache](https://mustache.github.io/) spec.
+[Rustache](https://rustache.github.io/rustache) is a [Rust](https://www.rust-lang.org/) implementation of the [Mustache](https://mustache.github.io/) spec.
 
 ## Documentation
 


### PR DESCRIPTION
This updates Travis to build against multiple versions of Rust and to generate the documentation so that it does not get stale.