### PR TITLE
Add From implementations for Data to simplify the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ The main forward interface that users will interact with when using Rustache are
 
 ```rust
 // Renders the given template string
-let data = rustache::HashBuilder::new().insert_string("name", "your name");
+let data = rustache::HashBuilder::new().insert("name", "your name");
 let rv = rustache::render_text("{{ name }}", data);
 println!("{}", String::from_utf8(rv.unwrap().into_inner()).unwrap());
 
 // Renders the given template file
-let data = rustache::HashBuilder::new().insert_string("name", "your name");
+let data = rustache::HashBuilder::new().insert("name", "your name");
 let rv = rustache::render_file("test_data/cmdline_test.tmpl", data);
 println!("{}", String::from_utf8(rv.unwrap().into_inner()).unwrap());
 ```
@@ -45,7 +45,7 @@ Here's an example of how to pass in data to the `render_text` method using the `
 
 ```rust
 let data = HashBuilder::new()
-    .insert_string("name", "Bob");
+    .insert("name", "Bob");
 
 rustache::render_text("{{ name }}", data);
 ```

--- a/src/build.rs
+++ b/src/build.rs
@@ -97,7 +97,7 @@ impl<'a> HashBuilder<'a> {
     /// ```
     pub fn insert_vector<F: FnOnce(VecBuilder<'a>) -> VecBuilder<'a>, K: ToString>(self, key: K, f: F) -> HashBuilder<'a> {
         let builder = f(VecBuilder::new());
-        self.insert(key, builder.build())
+        self.insert(key, builder)
     }
 
     /// Add a `Hash` to the `HashBuilder`
@@ -118,7 +118,7 @@ impl<'a> HashBuilder<'a> {
     /// ```
     pub fn insert_hash<F: FnOnce(HashBuilder<'a>) -> HashBuilder<'a>, K: ToString>(self, key: K, f: F) -> HashBuilder<'a> {
         let builder = f(HashBuilder::new());
-        self.insert(key, builder.build())
+        self.insert(key, builder)
     }
 
     /// Add a `Lambda` that accepts a String and returns a String to the `HashBuilder`
@@ -141,6 +141,12 @@ impl<'a> HashBuilder<'a> {
     /// Return the built `Data`
     fn build(self) -> Data<'a> {
         Hash(self.data)
+    }
+}
+
+impl<'a> From<HashBuilder<'a>> for Data<'a> {
+    fn from(v: HashBuilder<'a>) -> Data<'a> {
+        v.build()
     }
 }
 
@@ -234,7 +240,7 @@ impl<'a> VecBuilder<'a> {
     /// ```
     pub fn push_vector<F: FnOnce(VecBuilder<'a>) -> VecBuilder<'a>>(self, f: F) -> VecBuilder<'a> {
         let builder = f(VecBuilder::new());
-        self.push(builder.build())
+        self.push(builder)
     }
 
     /// Add a `Hash` to the `VecBuilder`
@@ -255,7 +261,7 @@ impl<'a> VecBuilder<'a> {
     /// ```
     pub fn push_hash<F: FnOnce(HashBuilder<'a>) -> HashBuilder<'a>>(self, f: F) -> VecBuilder<'a> {
         let builder = f(HashBuilder::new());
-        self.push(builder.build())
+        self.push(builder)
     }
 
     /// Add a `Lambda` to the `VecBuilder`
@@ -273,6 +279,12 @@ impl<'a> VecBuilder<'a> {
     /// Return the built `Data`
     fn build(self) -> Data<'a> {
         Vector(self.data)
+    }
+}
+
+impl<'a> From<VecBuilder<'a>> for Data<'a> {
+    fn from(v: VecBuilder<'a>) -> Data<'a> {
+        v.build()
     }
 }
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -30,95 +30,35 @@ impl<'a> HashBuilder<'a> {
     /// let data = HashBuilder::new()
     ///     .insert("game", "Hearthstone: Heroes of Warcraft");
     /// ```
+    /// ```rust
+    /// use rustache::{HashBuilder, VecBuilder};
+    /// let data = HashBuilder::new()
+    ///     .insert("classes",
+    ///         VecBuilder::new()
+    ///             .push("Mage".to_string())
+    ///             .push("Druid".to_string())
+    ///     );
+    /// ```
+    /// ```rust
+    /// use rustache::HashBuilder;
+    /// let data = HashBuilder::new()
+    ///     .insert("hero1",
+    ///         HashBuilder::new()
+    ///             .insert("first_name", "Anduin")
+    ///             .insert("last_name", "Wrynn")
+    ///     )
+    ///     .insert("hero2",
+    ///         HashBuilder::new()
+    ///             .insert("first_name", "Jaina")
+    ///             .insert("last_name", "Proudmoore")
+    ///     );
+    /// ```
     pub fn insert<K, V>(mut self, key: K, value: V) -> HashBuilder<'a>
         where K: ToString,
               V: Into<Data<'a>>,
     {
         self.data.insert(key.to_string(), value.into());
         self
-    }
-
-    /// Add a `String` to the `HashBuilder`
-    ///
-    /// ```rust
-    /// use rustache::HashBuilder;
-    /// let data = HashBuilder::new()
-    ///     .insert_string("game", "Hearthstone: Heroes of Warcraft");
-    /// ```
-    pub fn insert_string<K: ToString, V: ToString>(self, key: K, value: V) -> HashBuilder<'a> {
-        self.insert(key, value.to_string())
-    }
-
-    /// Add a `Boolean` to the `HashBuilder`
-    ///
-    /// ```rust
-    /// use rustache::HashBuilder;
-    /// let data = HashBuilder::new()
-    ///     .insert_bool("playing", true);
-    /// ```
-    pub fn insert_bool<K: ToString>(self, key: K, value: bool) -> HashBuilder<'a> {
-        self.insert(key, value)
-    }
-
-    /// Add an `Integer` to the `HashBuilder`
-    ///
-    /// ```rust
-    /// use rustache::HashBuilder;
-    /// let data = HashBuilder::new()
-    ///     .insert_int("age", 10i32)
-    ///     .insert_int("drinking age", -21i32);
-    /// ```
-    pub fn insert_int<K: ToString>(self, key: K, value: i32) -> HashBuilder<'a> {
-        self.insert(key, value)
-    }
-
-    /// Add a `Float` to the `HashBuilder`
-    ///
-    /// ```rust
-    /// use rustache::HashBuilder;
-    /// let data = HashBuilder::new()
-    ///     .insert_float("pi", 3.141596f64)
-    ///     .insert_float("phi", 1.61803398875f64);
-    /// ```
-    pub fn insert_float<K: ToString>(self, key: K, value: f64) -> HashBuilder<'a> {
-        self.insert(key, value)
-    }
-
-    /// Add a `Vector` to the `HashBuilder`
-    ///
-    /// ```rust
-    /// use rustache::HashBuilder;
-    /// let data = HashBuilder::new()
-    ///     .insert_vector("classes", |builder| {
-    ///         builder
-    ///             .push_string("Mage".to_string())
-    ///             .push_string("Druid".to_string())
-    ///     });
-    /// ```
-    pub fn insert_vector<F: FnOnce(VecBuilder<'a>) -> VecBuilder<'a>, K: ToString>(self, key: K, f: F) -> HashBuilder<'a> {
-        let builder = f(VecBuilder::new());
-        self.insert(key, builder)
-    }
-
-    /// Add a `Hash` to the `HashBuilder`
-    ///
-    /// ```rust
-    /// use rustache::HashBuilder;
-    /// let data = HashBuilder::new()
-    ///     .insert_hash("hero1", |builder| {
-    ///         builder
-    ///             .insert_string("first_name", "Anduin")
-    ///             .insert_string("last_name", "Wrynn")
-    ///     })
-    ///     .insert_hash("hero2", |builder| {
-    ///         builder
-    ///             .insert_string("first_name", "Jaina")
-    ///             .insert_string("last_name", "Proudmoore")
-    ///     });
-    /// ```
-    pub fn insert_hash<F: FnOnce(HashBuilder<'a>) -> HashBuilder<'a>, K: ToString>(self, key: K, f: F) -> HashBuilder<'a> {
-        let builder = f(HashBuilder::new());
-        self.insert(key, builder)
     }
 
     /// Add a `Lambda` that accepts a String and returns a String to the `HashBuilder`
@@ -172,96 +112,31 @@ impl<'a> VecBuilder<'a> {
     ///     .push("Mage")
     ///     .push("Druid");
     /// ```
+    /// ```rust
+    /// use rustache::VecBuilder;
+    /// let data = VecBuilder::new()
+    ///     .push(VecBuilder::new()
+    ///             .push("Anduin Wrynn".to_string())
+    ///             .push("Jaina Proudmoore".to_string())
+    ///     );
+    /// ```
+    /// ```rust
+    /// use rustache::{HashBuilder, VecBuilder};
+    /// let data = VecBuilder::new()
+    ///     .push(HashBuilder::new()
+    ///             .insert("first_name".to_string(), "Garrosh".to_string())
+    ///             .insert("last_name".to_string(), "Hellscream".to_string())
+    ///     )
+    ///     .push(HashBuilder::new()
+    ///             .insert("first_name".to_string(), "Malfurion".to_string())
+    ///             .insert("last_name".to_string(), "Stormrage".to_string())
+    ///     );
+    /// ```
     pub fn push<V>(mut self, value: V) -> VecBuilder<'a>
         where V: Into<Data<'a>>,
     {
         self.data.push(value.into());
         self
-    }
-
-    /// Add a `String` to the `VecBuilder`
-    ///
-    /// ```rust
-    /// use rustache::VecBuilder;
-    /// let data = VecBuilder::new()
-    ///     .push_string("Mage")
-    ///     .push_string("Druid");
-    /// ```
-    pub fn push_string<T: ToString>(self, value: T) -> VecBuilder<'a> {
-        self.push(value.to_string())
-    }
-
-    /// Add a `Bool` to the `VecBuilder`
-    ///
-    /// ```rust
-    /// use rustache::VecBuilder;
-    /// let data = VecBuilder::new()
-    ///     .push_bool(true)
-    ///     .push_bool(false);
-    /// ```
-    pub fn push_bool(self, value: bool) -> VecBuilder<'a> {
-        self.push(value)
-    }
-
-    /// Add an `Integer` to the `VecBuilder`
-    ///
-    /// ```rust
-    /// use rustache::VecBuilder;
-    /// let data = VecBuilder::new()
-    ///     .push_int(10i32)
-    ///     .push_int(-21i32);
-    /// ```
-    pub fn push_int(self, value: i32) -> VecBuilder<'a> {
-        self.push(value)
-    }
-
-    /// Add a `Float` to the `VecBuilder`
-    ///
-    /// ```rust
-    /// use rustache::VecBuilder;
-    /// let data = VecBuilder::new()
-    ///     .push_float(10.356356f64)
-    ///     .push_float(-21.34956230456f64);
-    /// ```
-    pub fn push_float(self, value: f64) -> VecBuilder<'a> {
-        self.push(value)
-    }
-
-    /// Add a `Vector` to the `VecBuilder`
-    ///
-    /// ```rust
-    /// use rustache::VecBuilder;
-    /// let data = VecBuilder::new()
-    ///     .push_vector(|builder| {
-    ///         builder
-    ///             .push_string("Anduin Wrynn".to_string())
-    ///             .push_string("Jaina Proudmoore".to_string())
-    ///     });
-    /// ```
-    pub fn push_vector<F: FnOnce(VecBuilder<'a>) -> VecBuilder<'a>>(self, f: F) -> VecBuilder<'a> {
-        let builder = f(VecBuilder::new());
-        self.push(builder)
-    }
-
-    /// Add a `Hash` to the `VecBuilder`
-    ///
-    /// ```rust
-    /// use rustache::VecBuilder;
-    /// let data = VecBuilder::new()
-    ///     .push_hash(|builder| {
-    ///         builder
-    ///             .insert_string("first_name".to_string(), "Garrosh".to_string())
-    ///             .insert_string("last_name".to_string(), "Hellscream".to_string())
-    ///     })
-    ///     .push_hash(|builder| {
-    ///         builder
-    ///             .insert_string("first_name".to_string(), "Malfurion".to_string())
-    ///             .insert_string("last_name".to_string(), "Stormrage".to_string())
-    ///     });
-    /// ```
-    pub fn push_hash<F: FnOnce(HashBuilder<'a>) -> HashBuilder<'a>>(self, f: F) -> VecBuilder<'a> {
-        let builder = f(HashBuilder::new());
-        self.push(builder)
     }
 
     /// Add a `Lambda` to the `VecBuilder`
@@ -328,22 +203,21 @@ mod tests {
             Hash(hearthstone))));
 
         let hash2 = HashBuilder::new().set_partials_path("/hearthstone")
-                        .insert_string("first_name", "Anduin")
-                        .insert_string("last_name", "Wrynn")
-                        .insert_int("age", 21i32)
-                        .insert_float("weight", 120.16f64)
-                        .insert_string("class", "Priest")
-                        .insert_bool("died", false)
-                        .insert_vector("class_cards", |builder| {
-                            builder
-                                .push_string(test_string)
-                                .push_string("Prophet Velen")
-                                .push_hash(|builder| {
-                                    builder
-                                        .insert_string("name", "Hearthstone: Heroes of Warcraft")
-                                        .insert_string("release_date", "December, 2014")
-                                })
-                        });
+                        .insert("first_name", "Anduin")
+                        .insert("last_name", "Wrynn")
+                        .insert("age", 21i32)
+                        .insert("weight", 120.16f64)
+                        .insert("class", "Priest")
+                        .insert("died", false)
+                        .insert("class_cards",
+                            VecBuilder::new()
+                                .push(test_string)
+                                .push("Prophet Velen")
+                                .push(HashBuilder::new()
+                                        .insert("name", "Hearthstone: Heroes of Warcraft")
+                                        .insert("release_date", "December, 2014")
+                                )
+                        );
 
         assert_eq!(Hash(hash1), Hash(hash2.data));
         assert_eq!(hash2.partials_path, "/hearthstone");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ extern crate rustc_serialize;
 use std::fmt;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::convert::From;
 
 use self::RustacheError::*;
 use self::Data::*;
@@ -53,6 +54,55 @@ pub enum Data<'a> {
     Hash(HashMap<String, Data<'a>>),
     Lambda(RefCell<&'a mut FnMut(String) -> String>)
 }
+
+impl<'a, 'b> From<&'b str> for Data<'a> {
+    fn from(v: &'b str) -> Data<'a> {
+        Strng(v.to_owned())
+    }
+}
+
+impl<'a> From<String> for Data<'a> {
+    fn from(v: String) -> Data<'a> {
+        Strng(v)
+    }
+}
+
+impl<'a> From<bool> for Data<'a> {
+    fn from(v: bool) -> Data<'a> {
+        Bool(v)
+    }
+}
+
+impl<'a> From<i32> for Data<'a> {
+    fn from(v: i32) -> Data<'a> {
+        Integer(v)
+    }
+}
+
+impl<'a> From<f64> for Data<'a> {
+    fn from(v: f64) -> Data<'a> {
+        Float(v)
+    }
+}
+
+impl<'a> From<Vec<Data<'a>>> for Data<'a> {
+    fn from(v: Vec<Data<'a>>) -> Data<'a> {
+        Vector(v)
+    }
+}
+
+impl<'a> From<HashMap<String, Data<'a>>> for Data<'a> {
+    fn from(v: HashMap<String, Data<'a>>) -> Data<'a> {
+        Hash(v)
+    }
+}
+
+impl<'a> From<&'a mut FnMut(String) -> String> for Data<'a> {
+    fn from(v: &'a mut FnMut(String) -> String) -> Data<'a> {
+        Lambda(RefCell::new(v))
+    }
+}
+
 // |String|: 'a -> String : F Above
 
 // Implementing custom PartialEq for Data

--- a/tests/test_spec_interpolation.rs
+++ b/tests/test_spec_interpolation.rs
@@ -27,7 +27,7 @@ fn test_spec_interpolation_none() {
 //     Hello, world!
 #[test]
 fn test_spec_interpolation_basic() {
-    let data = HashBuilder::new().insert_string("subject", "world");
+    let data = HashBuilder::new().insert("subject", "world");
 
     let rv = rustache::render_text("Hello, {{subject}}!", data);
 
@@ -43,7 +43,7 @@ fn test_spec_interpolation_basic() {
 //     These characters should be HTML escaped: &amp; &quot; &lt; &gt;
 #[test]
 fn test_spec_interpolation_html_escaping() {
-    let data = HashBuilder::new().insert_string("forbidden", "& \" < >");
+    let data = HashBuilder::new().insert("forbidden", "& \" < >");
 
     let rv = rustache::render_text("These characters should be HTML escaped: {{forbidden}}", data);
 
@@ -59,7 +59,7 @@ fn test_spec_interpolation_html_escaping() {
 //     These characters should not be HTML escaped: & " < >
 #[test]
 fn test_spec_interpolation_no_html_escaping_triple_mustache() {
-    let data = HashBuilder::new().insert_string("forbidden", "& \" < >");
+    let data = HashBuilder::new().insert("forbidden", "& \" < >");
 
     let rv = rustache::render_text("These characters should not be HTML escaped: {{{forbidden}}}", data);
 
@@ -75,7 +75,7 @@ fn test_spec_interpolation_no_html_escaping_triple_mustache() {
 //     These characters should not be HTML escaped: & " < >
 #[test]
 fn test_spec_interpolation_no_html_escaping_ampersand() {
-    let data = HashBuilder::new().insert_string("forbidden", "& \" < >");
+    let data = HashBuilder::new().insert("forbidden", "& \" < >");
 
     let rv = rustache::render_text("These characters should not be HTML escaped: {{&forbidden}}", data);
 
@@ -89,7 +89,7 @@ fn test_spec_interpolation_no_html_escaping_ampersand() {
 //   expected: '"85 miles an hour!"'
 #[test]
 fn test_spec_interpolation_integer_basic() {
-    let data = HashBuilder::new().insert_int("mph", 85);
+    let data = HashBuilder::new().insert("mph", 85);
 
     let rv = rustache::render_text("{{mph}} miles an hour!", data);
 
@@ -103,7 +103,7 @@ fn test_spec_interpolation_integer_basic() {
 //   expected: '"85 miles an hour!"'
 #[test]
 fn test_spec_interpolation_integer_triple_mustache() {
-    let data = HashBuilder::new().insert_int("mph", 85);
+    let data = HashBuilder::new().insert("mph", 85);
 
     let rv = rustache::render_text("{{{mph}}} miles an hour!", data);
 
@@ -117,7 +117,7 @@ fn test_spec_interpolation_integer_triple_mustache() {
 //   expected: '"85 miles an hour!"'
 #[test]
 fn test_spec_interpolation_integer_ampersand() {
-    let data = HashBuilder::new().insert_int("mph", 85);
+    let data = HashBuilder::new().insert("mph", 85);
 
     let rv = rustache::render_text("{{mph}} miles an hour!", data);
 
@@ -131,7 +131,7 @@ fn test_spec_interpolation_integer_ampersand() {
 //   expected: '"1.21 jiggawatts!"'
 #[test]
 fn test_spec_interpolation_float_basic() {
-    let data = HashBuilder::new().insert_float("power", 1.210);
+    let data = HashBuilder::new().insert("power", 1.210);
 
     let rv = rustache::render_text("{{power}} jiggawatts!", data);
 
@@ -145,7 +145,7 @@ fn test_spec_interpolation_float_basic() {
 //   expected: '"1.21 jiggawatts!"'
 #[test]
 fn test_spec_interpolation_float_triple_mustache() {
-    let data = HashBuilder::new().insert_float("power", 1.210);
+    let data = HashBuilder::new().insert("power", 1.210);
 
     let rv = rustache::render_text("{{{power}}} jiggawatts!", data);
 
@@ -159,7 +159,7 @@ fn test_spec_interpolation_float_triple_mustache() {
 //   expected: '"1.21 jiggawatts!"'
 #[test]
 fn test_spec_interpolation_float_ampersand() {
-    let data = HashBuilder::new().insert_float("power", 1.210);
+    let data = HashBuilder::new().insert("power", 1.210);
 
     let rv = rustache::render_text("{{&power}} jiggawatts!", data);
 
@@ -215,7 +215,7 @@ fn test_spec_interpolation_context_miss_ampersand() {
 //   expected: '"Joe" == "Joe"'
 #[test]
 fn test_spec_interpolation_dotted_names_basic() {
-    let data = HashBuilder::new().insert_hash("person", |h| { h.insert_string("name", "Joe") });
+    let data = HashBuilder::new().insert("person", HashBuilder::new().insert("name", "Joe"));
 
     let rv = rustache::render_text("\"{{person.name}}\" == \"{{#person}}{{name}}{{/person}}\"", data);
 
@@ -230,9 +230,9 @@ fn test_spec_interpolation_dotted_names_basic() {
 #[test]
 fn test_spec_interpolation_dotted_names_triple_mustache() {
     let data = HashBuilder::new()
-                .insert_hash("person", |h| {
-                    h.insert_string("name", "Joe")
-                });
+                .insert("person", HashBuilder::new()
+                    .insert("name", "Joe")
+                );
 
     let rv = rustache::render_text("\"{{{person.name}}}\" == \"{{#person}}{{{name}}}{{/person}}\"", data);
 
@@ -247,9 +247,9 @@ fn test_spec_interpolation_dotted_names_triple_mustache() {
 #[test]
 fn test_spec_interpolation_dotted_names_ampersand() {
     let data = HashBuilder::new()
-                .insert_hash("person", |h| {
-                    h.insert_string("name", "Joe")
-                });
+                .insert("person", HashBuilder::new()
+                    .insert("name", "Joe")
+                );
 
     let rv = rustache::render_text("\"{{&person.name}}\" == \"{{#person}}{{&name}}{{/person}}\"", data);
 
@@ -265,17 +265,17 @@ fn test_spec_interpolation_dotted_names_ampersand() {
 #[test]
 fn test_spec_interpolation_dotted_names_arbitrary_depth() {
     let data = HashBuilder::new()
-                .insert_hash("a", |h| { 
-                    h.insert_hash("b", |h| {
-                        h.insert_hash("c", |h| {
-                            h.insert_hash("d", |h| {
-                                h.insert_hash("e", |h| { 
-                                    h.insert_string("name", "Phil")
-                                })
-                            })
-                        })
-                    })
-                });
+                .insert("a", HashBuilder::new()
+                    .insert("b", HashBuilder::new()
+                        .insert("c", HashBuilder::new()
+                            .insert("d", HashBuilder::new()
+                                .insert("e", HashBuilder::new()
+                                    .insert("name", "Phil")
+                                )
+                            )
+                        )
+                    )
+                );
 
     let rv = rustache::render_text("\"{{a.b.c.d.e.name}}\" == \"Phil\"", data);
 
@@ -307,14 +307,12 @@ fn test_spec_interpolation_dotted_broken_chains() {
 #[test]
 fn test_spec_interpolation_dotted_broken_chain_resolution() {
     let data = HashBuilder::new()
-                .insert_hash("a", |h| {
-                    h.insert_hash("b", |h| {
-                        h
-                    })
-                })
-                .insert_hash("c", |h| {
-                    h.insert_string("name", "Jim")
-                });
+                .insert("a", HashBuilder::new()
+                    .insert("b", HashBuilder::new())
+                )
+                .insert("c", HashBuilder::new()
+                    .insert("name", "Jim")
+                );
 
     let rv = rustache::render_text("\"{{a.b.c}}\" == \"\"", data);
 
@@ -331,26 +329,26 @@ fn test_spec_interpolation_dotted_broken_chain_resolution() {
 #[test]
 fn test_spec_interpolation_dotted_initial_resolution() {
     let data = HashBuilder::new()
-                .insert_hash("a", |h| { 
-                    h.insert_hash("b", |h| {
-                        h.insert_hash("c", |h| {
-                            h.insert_hash("d", |h| {
-                                h.insert_hash("e", |h| { 
-                                    h.insert_string("name", "Phil")
-                                })
-                            })
-                        })
-                    })
-                })
-                .insert_hash("b", |h| {
-                    h.insert_hash("c", |h| {
-                        h.insert_hash("d", |h| {
-                            h.insert_hash("e", |h| { 
-                                h.insert_string("name", "Wrong")
-                            })
-                        })
-                    })
-                });
+                .insert("a", HashBuilder::new()
+                    .insert("b", HashBuilder::new()
+                        .insert("c", HashBuilder::new()
+                            .insert("d", HashBuilder::new()
+                                .insert("e", HashBuilder::new()
+                                    .insert("name", "Phil")
+                                )
+                            )
+                        )
+                    )
+                )
+                .insert("b", HashBuilder::new()
+                    .insert("c", HashBuilder::new()
+                        .insert("d", HashBuilder::new()
+                            .insert("e", HashBuilder::new()
+                                .insert("name", "Wrong")
+                            )
+                        )
+                    )
+                );
 
     let rv = rustache::render_text("\"{{#a}}{{b.c.d.e.name}}{{/a}}\" == \"Phil\"", data);
 
@@ -367,16 +365,14 @@ fn test_spec_interpolation_dotted_initial_resolution() {
 #[test]
 fn test_spec_interpolation_dotted_context_precedence() {
     let data = HashBuilder::new()
-                .insert_hash("a", |h| {
-                    h.insert_hash("b", |h| {
-                        h
-                    })
-                })
-                .insert_hash("b", |h| {
-                    h.insert_hash("c", |h| {
-                        h.insert_string("name", "ERROR")
-                    })
-                });
+                .insert("a", HashBuilder::new()
+                    .insert("b", HashBuilder::new())
+                )
+                .insert("b", HashBuilder::new()
+                    .insert("c", HashBuilder::new()
+                        .insert("name", "ERROR")
+                    )
+                );
 
     let rv = rustache::render_text("{{#a}}{{b.c}}{{/a}}", data);
 
@@ -390,7 +386,7 @@ fn test_spec_interpolation_dotted_context_precedence() {
 //   expected: '| --- |'
 #[test]
 fn test_spec_interpolation_surrounding_whitespace_basic() {
-    let data = HashBuilder::new().insert_string("string", "---");
+    let data = HashBuilder::new().insert("string", "---");
 
     let rv = rustache::render_text("| {{string}} |", data);
 
@@ -404,7 +400,7 @@ fn test_spec_interpolation_surrounding_whitespace_basic() {
 //   expected: '| --- |'
 #[test]
 fn test_spec_interpolation_surrounding_whitespace_triple_mustache() {
-    let data = HashBuilder::new().insert_string("string", "---");
+    let data = HashBuilder::new().insert("string", "---");
 
     let rv = rustache::render_text("| {{{string}}} |", data);
 
@@ -418,7 +414,7 @@ fn test_spec_interpolation_surrounding_whitespace_triple_mustache() {
 //   expected: '| --- |'
 #[test]
 fn test_spec_interpolation_surrounding_whitespace_ampersand() {
-    let data = HashBuilder::new().insert_string("string", "---");
+    let data = HashBuilder::new().insert("string", "---");
 
     let rv = rustache::render_text("| {{&string}} |", data);
 
@@ -432,7 +428,7 @@ fn test_spec_interpolation_surrounding_whitespace_ampersand() {
 //   expected: "  ---\n"
 #[test]
 fn test_spec_interpolation_standalone_basic() {
-    let data = HashBuilder::new().insert_string("string", "---");
+    let data = HashBuilder::new().insert("string", "---");
 
     let rv = rustache::render_text("  {{string}}\n", data);
 
@@ -446,7 +442,7 @@ fn test_spec_interpolation_standalone_basic() {
 //   expected: "  ---\n"
 #[test]
 fn test_spec_interpolation_standalone_triple_mustache() {
-    let data = HashBuilder::new().insert_string("string", "---");
+    let data = HashBuilder::new().insert("string", "---");
 
     let rv = rustache::render_text("  {{{string}}}\n", data);
 
@@ -460,7 +456,7 @@ fn test_spec_interpolation_standalone_triple_mustache() {
 //   expected: "  ---\n"
 #[test]
 fn test_spec_interpolation_standalone_ampersand() {
-    let data = HashBuilder::new().insert_string("string", "---");
+    let data = HashBuilder::new().insert("string", "---");
 
     let rv = rustache::render_text("  {{&string}}\n", data);
 
@@ -474,7 +470,7 @@ fn test_spec_interpolation_standalone_ampersand() {
 //   expected: '|---|'
 #[test]
 fn test_spec_interpolation_with_padding() {
-  let data = HashBuilder::new().insert_string("string", "---");
+  let data = HashBuilder::new().insert("string", "---");
 
   let rv = rustache::render_text("|{{ string }}|", data);
 
@@ -488,7 +484,7 @@ fn test_spec_interpolation_with_padding() {
 //   expected: '|---|'
 #[test]
 fn test_spec_interpolation_triple_mustache_with_padding() {
-    let data = HashBuilder::new().insert_string("string", "---");
+    let data = HashBuilder::new().insert("string", "---");
 
     let rv = rustache::render_text("|{{{ string }}}|", data);
 
@@ -502,10 +498,10 @@ fn test_spec_interpolation_triple_mustache_with_padding() {
 //   expected: '|---|'
 #[test]
 fn test_spec_interpolation_ampersand_with_padding() {
-    let data = HashBuilder::new().insert_string("string", "---");
+    let data = HashBuilder::new().insert("string", "---");
 
     let rv = rustache::render_text("|{{& string }}|", data);
-    
+
     assert_eq!("|---|".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
 }
 

--- a/tests/test_spec_lambdas.rs
+++ b/tests/test_spec_lambdas.rs
@@ -42,7 +42,7 @@ fn test_spec_lambdas_interpolation() {
 fn test_spec_lambdas_interpolation_expansion() {
     let mut f = |_| { "{{planet}}".to_string() };
     let data = HashBuilder::new()
-                    .insert_string("planet", "world")
+                    .insert("planet", "world")
                     .insert_lambda("lambda", &mut f);
 
     let rv = rustache::render_text("Hello, {{lambda}}!", data);
@@ -66,7 +66,7 @@ fn test_spec_lambdas_interpolation_expansion() {
 // #[test]
 // fn test_spec_lambdas_interpolation_alternate_delimeters() {
 //     let data = HashBuilder::new()
-//                 .insert_string("planet", "world")
+//                 .insert("planet", "world")
 //                 .insert_lambda("lambda", |_| {
 //                     "|planet| => {{planet}}".to_string()               
 //                 });
@@ -149,7 +149,7 @@ fn test_spec_lambdas_section() {
                     }
                 };
     let data = HashBuilder::new()
-                .insert_string("x", "Error!")
+                .insert("x", "Error!")
                 .insert_lambda("lambda", &mut f);
 
     let rv = rustache::render_text("<{{#lambda}}{{x}}{{/lambda}}>", data);
@@ -179,7 +179,7 @@ fn test_spec_lambdas_section_expansion() {
                    result
                 };
     let data = HashBuilder::new()
-                .insert_string("planet", "Earth")
+                .insert("planet", "Earth")
                 .insert_lambda("lambda", &mut f);
 
     let rv = rustache::render_text("<{{#lambda}}-{{/lambda}}>", data);
@@ -203,7 +203,7 @@ fn test_spec_lambdas_section_expansion() {
 // #[test]
 // fn test_spec_lambdas_section_alternate_delimeters() {
 //     let data = HashBuilder::new()
-//                 .insert_string("planet", "Earth")
+//                 .insert("planet", "Earth")
 //                 .insert_lambda("lambda", |txt| {
 //                     let mut result = txt.to_string();
 //                     result.push_str("{{planet}} => |planet|");
@@ -261,7 +261,7 @@ fn test_spec_lambdas_section_multiple_calls() {
 fn test_spec_lambdas_inverted_section() {
     let mut f = |_| { "false".to_string() };
     let data = HashBuilder::new()
-                .insert_string("static", "static")
+                .insert("static", "static")
                 .insert_lambda("lambda", &mut f);
 
     let rv = rustache::render_text("<{{^lambda}}{{static}}{{/lambda}}>", data);

--- a/tests/test_spec_partials.rs
+++ b/tests/test_spec_partials.rs
@@ -40,7 +40,7 @@ fn test_spec_partials_failed_lookup() {
 //     expected: '"*content*"'
 #[test]
 fn test_spec_partials_context() {
-    let data = HashBuilder::new().insert_string("text", "content");
+    let data = HashBuilder::new().insert("text", "content");
 
     let rv = rustache::render_text("\"{{>test_data/test_spec_partials_context}}\"", data);
 
@@ -56,10 +56,10 @@ fn test_spec_partials_context() {
 // #[test]
 // fn test_spec_partials_recursion() {
 //     let data = HashBuilder::new()
-//                 .insert_string("content", "X")
+//                 .insert("content", "X")
 //                 .insert_vector("nodes", |v| {
 //                     v.push_hash(|h| {
-//                         h.insert_string("content", "Y")
+//                         h.insert("content", "Y")
 //                          .insert_vector("nodes", |v| {
 //                             v
 //                          })
@@ -94,7 +94,7 @@ fn test_spec_partials_surrounding_whitespace() {
 //     expected: "  |  >\n>\n"
 #[test]
 fn test_spec_partials_inline_indentation() {
-    let data = HashBuilder::new().insert_string("data", "|");
+    let data = HashBuilder::new().insert("data", "|");
 
     let rv = rustache::render_text("  {{data}}  {{> test_data/test_spec_partials_inline_indentation}}\n", data);
 
@@ -167,7 +167,7 @@ fn test_spec_partials_standalone_without_newline() {
 //       /
 // #[test]
 // fn test_spec_partials_standalone_indentation() {
-//     let data = HashBuilder::new().insert_string("content", "<\n->");
+//     let data = HashBuilder::new().insert("content", "<\n->");
 
 //     let rv = rustache::render_text("|\n\\\n {{>test_data/test_spec_partials_standalone_indentation}}\n/\n", data);
 
@@ -183,7 +183,7 @@ fn test_spec_partials_standalone_without_newline() {
 #[test]
 fn test_spec_partials_padding_whitespace() {
     let data = HashBuilder::new()
-                .insert_bool("boolean", true);
+                .insert("boolean", true);
 
     let rv = rustache::render_text("|{{> test_data/test_spec_partials_padding_whitespace }}|", data);
 

--- a/tests/test_spec_sections.rs
+++ b/tests/test_spec_sections.rs
@@ -1,6 +1,6 @@
 extern crate rustache;
 
-use rustache::HashBuilder;
+use rustache::{HashBuilder, VecBuilder};
 
 // - name: Truthy
 //   desc: Truthy sections should have their contents rendered.
@@ -10,7 +10,7 @@ use rustache::HashBuilder;
 #[test]
 fn test_spec_sections_truthy_should_render_contents() {
     let data = HashBuilder::new()
-        .insert_bool("boolean", true);
+        .insert("boolean", true);
 
     let rv = rustache::render_text("{{#boolean}}This should be rendered.{{/boolean}}", data);
 
@@ -25,7 +25,7 @@ fn test_spec_sections_truthy_should_render_contents() {
 #[test]
 fn test_spec_sections_falsy_should_not_render_contents() {
     let data = HashBuilder::new()
-        .insert_bool("boolean", false);
+        .insert("boolean", false);
 
     let rv = rustache::render_text("{{#boolean}}This should not be rendered.{{/boolean}}", data);
 
@@ -40,10 +40,9 @@ fn test_spec_sections_falsy_should_not_render_contents() {
 #[test]
 fn test_spec_sections_objects_and_hashes_should_be_pushed_onto_context_stack() {
     let data = HashBuilder::new()
-        .insert_hash("context", |builder| {
-            builder
-                .insert_string("name", "Joe")
-        });
+        .insert("context", HashBuilder::new()
+                .insert("name", "Joe")
+        );
 
     let rv = rustache::render_text("{{#context}}Hi {{name}}.{{/context}}", data);
 
@@ -154,21 +153,17 @@ fn test_spec_sections_objects_and_hashes_should_be_pushed_onto_context_stack() {
 #[test]
 fn test_spec_sections_list_items_are_iterated() {
     let data = HashBuilder::new()
-        .insert_vector("list", |builder| {
-            builder
-                .push_hash(|builder| {
-                    builder
-                        .insert_string("item".to_string(), "1".to_string())
-                })
-                .push_hash(|builder| {
-                    builder
-                        .insert_string("item".to_string(), "2".to_string())
-                })
-                .push_hash(|builder| {
-                    builder
-                        .insert_string("item".to_string(), "3".to_string())
-                })
-        });
+        .insert("list", VecBuilder::new()
+                .push(HashBuilder::new()
+                        .insert("item".to_string(), "1".to_string())
+                )
+                .push(HashBuilder::new()
+                        .insert("item".to_string(), "2".to_string())
+                )
+                .push(HashBuilder::new()
+                        .insert("item".to_string(), "3".to_string())
+                )
+        );
 
     let rv = rustache::render_text("{{#list}}{{item}}{{/list}}", data);
 
@@ -183,9 +178,7 @@ fn test_spec_sections_list_items_are_iterated() {
 #[test]
 fn test_spec_sections_empty_lists_behave_like_falsy_values() {
     let data = HashBuilder::new()
-        .insert_vector("list", |builder| {
-            builder
-        });
+        .insert("list", VecBuilder::new());
 
     let rv = rustache::render_text("{{#list}}Yay lists!{{/list}}", data);
 
@@ -211,7 +204,7 @@ fn test_spec_sections_empty_lists_behave_like_falsy_values() {
 // fn test_spec_sections_multiple_per_template_permitted() {
 //     let data = HashBuilder::new()
 //         .insert_bool("bool", true)
-//         .insert_string("two", "second");
+//         .insert("two", "second");
 
 //     let rv = rustache::render_text("{{#bool}}
 //                            * first
@@ -239,7 +232,7 @@ fn test_spec_sections_empty_lists_behave_like_falsy_values() {
 #[test]
 fn test_spec_sections_nested_truthy_contents_render() {
     let data = HashBuilder::new()
-        .insert_bool("bool", true);
+        .insert("bool", true);
 
     let rv = rustache::render_text("| A {{#bool}}B {{#bool}}C{{/bool}} D{{/bool}} E |", data);
 
@@ -254,7 +247,7 @@ fn test_spec_sections_nested_truthy_contents_render() {
 #[test]
 fn test_spec_sections_nested_falsy_contents_do_not_render() {
     let data = HashBuilder::new()
-        .insert_bool("bool", false);
+        .insert("bool", false);
 
     let rv = rustache::render_text("| A {{#bool}}B {{#bool}}C{{/bool}} D{{/bool}} E |", data);
 
@@ -373,13 +366,11 @@ fn test_spec_sections_failed_context_lookups_are_falsy() {
 #[test]
 fn test_spec_sections_falsy_dotted_names_are_not_valid_section_tags() {
     let data = HashBuilder::new()
-        .insert_hash("a", |builder| {
-            builder
-                .insert_hash("b", |builder| {
-                    builder
-                        .insert_bool("c", false)
-            })
-        });
+        .insert("a", HashBuilder::new()
+                .insert("b", HashBuilder::new()
+                        .insert("c", false)
+            )
+        );
 
     let rv = rustache::render_text("'{{#a.b.c}}Here{{/a.b.c}}' == ''", data);
 
@@ -394,9 +385,7 @@ fn test_spec_sections_falsy_dotted_names_are_not_valid_section_tags() {
 #[test]
 fn test_spec_sections_unresolved_dotted_names_are_not_valid_section_tags() {
     let data = HashBuilder::new()
-        .insert_hash("a", |builder| {
-            builder
-        });
+        .insert("a", HashBuilder::new());
 
     let rv = rustache::render_text("'{{#a.b.c}}Here{{/a.b.c}}' == ''", data);
 
@@ -411,7 +400,7 @@ fn test_spec_sections_unresolved_dotted_names_are_not_valid_section_tags() {
 #[test]
 fn test_spec_sections_do_not_alter_surrounding_whitespace() {
     let data = HashBuilder::new()
-        .insert_bool("boolean", true);
+        .insert("boolean", true);
 
     let rv = rustache::render_text(" | {{#boolean}}\t|\t{{/boolean}} | \n", data);
 
@@ -441,7 +430,7 @@ fn test_spec_sections_do_not_alter_surrounding_whitespace() {
 #[test]
 fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace() {
     let data = HashBuilder::new()
-        .insert_bool("boolean", true);
+        .insert("boolean", true);
 
     let rv = rustache::render_text(" {{#boolean}}YES{{/boolean}}\n {{#boolean}}GOOD{{/boolean}}\n", data);
 
@@ -464,7 +453,7 @@ fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace()
 // #[test]
 // fn test_spec_sections_standalone_lines_are_removed_from_template() {
 //     let data = HashBuilder::new()
-//         .insert_bool("boolean", true);
+//         .insert("boolean", true);
 
 //     let rv = rustache::render_text("|
 //                            | This Is
@@ -572,7 +561,7 @@ fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace()
 #[test]
 fn test_spec_sections_superfluous_tag_whitespace_is_ignored() {
     let data = HashBuilder::new()
-        .insert_bool("boolean", true);
+        .insert("boolean", true);
 
     let rv = rustache::render_text("|{{# boolean }}={{/ boolean }}|", data);
 


### PR DESCRIPTION
By adding `From` implementations for all of the different data types allowed for the `HashBuilder` and `VecBuilder` APIs, we can vastly simplify those APIs down to basically a simple `insert` or `push` instead of an `insert_string`, `insert_int`, `insert_float`, etc.