### PR TITLE
Refactor the render API to feel more native

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,14 @@ extern crate rustache;
 
 ## API Methods
 
-The main forward interface that users will interact with when using Rustache are the `rustache::render_file` method and the `rustache::render_text` methods like so:
+The main forward interface that users will interact with when using Rustache
+is the `render` method provided by the `rustache::Render` trait like so:
 
 ```rust
 // Renders the given template string
 let data = rustache::HashBuilder::new().insert("name", "your name");
 let out = Cursor::new(Vec::new());
-rustache::render_text("{{ name }}", data, &mut out).unwrap();
-println!("{}", String::from_utf8(rv.unwrap().into_inner()).unwrap());
-
-// Renders the given template file
-let data = rustache::HashBuilder::new().insert("name", "your name");
-let out = Cursor::new(Vec::new());
-rustache::render_file("test_data/cmdline_test.tmpl", data, &mut out).unwrap();
+data.render("{{ name }}", &mut out).unwrap();
 println!("{}", String::from_utf8(rv.unwrap().into_inner()).unwrap());
 ```
 
@@ -50,7 +45,7 @@ let data = HashBuilder::new()
     .insert("name", "Bob");
 let out = Cursor::new(Vec::new());
 
-rustache::render_text("{{ name }}", data, &mut out);
+data.render("{{ name }}", &mut out);
 ```
 
 Here's an example of how to pass in data in the form of a JSON `enum` to a `render` method:
@@ -59,7 +54,7 @@ Here's an example of how to pass in data in the form of a JSON `enum` to a `rend
 let data = json::from_str(r#"{"name": "Bob"}"#);
 let out = Cursor::new(Vec::new());
 
-rustache::render_text("{{ name }}", data, &mut out);
+data.render("{{ name }}", &mut out);
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -30,12 +30,14 @@ The main forward interface that users will interact with when using Rustache are
 ```rust
 // Renders the given template string
 let data = rustache::HashBuilder::new().insert("name", "your name");
-let rv = rustache::render_text("{{ name }}", data);
+let out = Cursor::new(Vec::new());
+rustache::render_text("{{ name }}", data, &mut out).unwrap();
 println!("{}", String::from_utf8(rv.unwrap().into_inner()).unwrap());
 
 // Renders the given template file
 let data = rustache::HashBuilder::new().insert("name", "your name");
-let rv = rustache::render_file("test_data/cmdline_test.tmpl", data);
+let out = Cursor::new(Vec::new());
+rustache::render_file("test_data/cmdline_test.tmpl", data, &mut out).unwrap();
 println!("{}", String::from_utf8(rv.unwrap().into_inner()).unwrap());
 ```
 
@@ -46,16 +48,18 @@ Here's an example of how to pass in data to the `render_text` method using the `
 ```rust
 let data = HashBuilder::new()
     .insert("name", "Bob");
+let out = Cursor::new(Vec::new());
 
-rustache::render_text("{{ name }}", data);
+rustache::render_text("{{ name }}", data, &mut out);
 ```
 
 Here's an example of how to pass in data in the form of a JSON `enum` to a `render` method:
 
 ```rust
 let data = json::from_str(r#"{"name": "Bob"}"#);
+let out = Cursor::new(Vec::new());
 
-rustache::render_text("{{ name }}", data);
+rustache::render_text("{{ name }}", data, &mut out);
 ```
 
 ## Testing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use self::RustacheError::*;
 use self::Data::*;
 
 pub use build::{HashBuilder, VecBuilder};
-pub use rustache::{render_file, render_text, Render};
+pub use rustache::{render_text, Render};
 
 /// Alias for Result<T, RustacheError>
 pub type RustacheResult<T> = Result<T, RustacheError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use self::RustacheError::*;
 use self::Data::*;
 
 pub use build::{HashBuilder, VecBuilder};
-pub use rustache::{render_text, Render};
+pub use rustache::Render;
 
 /// Alias for Result<T, RustacheError>
 pub type RustacheResult<T> = Result<T, RustacheError>;

--- a/src/rustache.rs
+++ b/src/rustache.rs
@@ -70,25 +70,6 @@ impl Render for ToString {
     }
 }
 
-/// Render a template from the given template file
-///
-/// ```
-/// use rustache::HashBuilder;
-/// use std::io::Cursor;
-///
-/// let data = HashBuilder::new().insert("planet", "Earth");
-/// let mut rv = Cursor::new(Vec::new());
-/// rustache::render_file("test_data/cmdline_test.tmpl", data, &mut rv).unwrap();
-/// println!("{}", String::from_utf8(rv.into_inner()).unwrap());
-/// ```
-pub fn render_file<Re: Render, W: Write>(path: &str, renderable: Re, writer: &mut W) -> RustacheResult<()> {
-
-    return match read_file(&Path::new(path)) {
-        Ok(text) => renderable.render(&text[..], writer),
-        Err(err) => Err(FileError(err))
-    }
-}
-
 /// Render the given template string
 ///
 /// ```

--- a/src/rustache.rs
+++ b/src/rustache.rs
@@ -70,21 +70,6 @@ impl Render for ToString {
     }
 }
 
-/// Render the given template string
-///
-/// ```
-/// use rustache::HashBuilder;
-/// use std::io::Cursor;
-///
-/// let data = HashBuilder::new().insert("name", "your name");
-/// let mut rv = Cursor::new(Vec::new());
-/// rustache::render_text("{{ name }}", data, &mut rv).unwrap();
-/// println!("{}", String::from_utf8(rv.into_inner()).unwrap());
-/// ```
-pub fn render_text<Re: Render, W: Write>(input: &str, renderable: Re, writer: &mut W) -> RustacheResult<()> {
-    renderable.render(input, writer)
-}
-
 // parses a Rust JSON hash and matches all possible types that may be passed in
 // returning a HashBuilder 
 fn parse_json(json: &Json) -> HashBuilder {

--- a/tests/test_spec_comments.rs
+++ b/tests/test_spec_comments.rs
@@ -1,6 +1,7 @@
 extern crate rustache;
 
 use rustache::HashBuilder;
+use std::io::Cursor;
 
 // - name: Inline
 //   desc: Comment blocks should be removed from the template.
@@ -10,9 +11,10 @@ use rustache::HashBuilder;
 #[test]
 fn test_spec_inline_comment() {
     let data = HashBuilder::new();
-    let rv = rustache::render_text("12345{{! Comment Block! }}67890", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("12345{{! Comment Block! }}67890", data, &mut rv).unwrap();
 
-    assert_eq!("1234567890".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("1234567890".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Multiline
@@ -28,9 +30,10 @@ fn test_spec_inline_comment() {
 #[test]
 fn test_spec_multiline_comment() {
     let data = HashBuilder::new();
-    let rv = rustache::render_text("12345{{!\nThis is a\nmulti-line comment...\n}}67890", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("12345{{!\nThis is a\nmulti-line comment...\n}}67890", data, &mut rv).unwrap();
 
-    assert_eq!("1234567890".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("1234567890".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Standalone
@@ -46,9 +49,10 @@ fn test_spec_multiline_comment() {
 #[test]
 fn test_spec_standalone_comment() {
     let data = HashBuilder::new();
-    let rv = rustache::render_text("Begin.\n{{! Comment Block! }}\nEnd.", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("Begin.\n{{! Comment Block! }}\nEnd.", data, &mut rv).unwrap();
 
-    assert_eq!("Begin.\nEnd.".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("Begin.\nEnd.".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Indented Standalone
@@ -64,9 +68,10 @@ fn test_spec_standalone_comment() {
 #[test]
 fn test_spec_indented_standalone_comment() {
     let data = HashBuilder::new();
-    let rv = rustache::render_text("Begin.\n\t{{! Indented Comment Block! }}\nEnd.", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("Begin.\n\t{{! Indented Comment Block! }}\nEnd.", data, &mut rv).unwrap();
 
-    assert_eq!("Begin.\nEnd.".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("Begin.\nEnd.".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Standalone Line Endings
@@ -77,9 +82,10 @@ fn test_spec_indented_standalone_comment() {
 #[test]
 fn test_spec_standalone_line_ending_comment() {
     let data = HashBuilder::new();
-    let rv = rustache::render_text("|\r\n{{! Standalone Comment }}\r\n|", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("|\r\n{{! Standalone Comment }}\r\n|", data, &mut rv).unwrap();
 
-    assert_eq!("|\r\n|".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("|\r\n|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Standalone Without Previous Line
@@ -90,9 +96,10 @@ fn test_spec_standalone_line_ending_comment() {
 // #[test]
 // fn test_spec_standalone_without_prev_line_comment() {
 //     let data = HashBuilder::new();
-//     let rv = rustache::render_text("  {{! I'm Still Standalone }}\n!", data);
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("  {{! I'm Still Standalone }}\n!", data, &mut rv).unwrap();
 
-//     assert_eq!("!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 // - name: Standalone Without Newline
@@ -103,9 +110,10 @@ fn test_spec_standalone_line_ending_comment() {
 // #[test]
 // fn test_spec_standalone_without_newline_comment() {
 //     let data = HashBuilder::new();
-//     let rv = rustache::render_text("!\n  {{! I'm Still Standalone }}", data);
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("!\n  {{! I'm Still Standalone }}", data, &mut rv).unwrap();
 
-//     assert_eq!("!\n".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("!\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 // - name: Multiline Standalone
@@ -123,9 +131,10 @@ fn test_spec_standalone_line_ending_comment() {
 #[test]
 fn test_spec_multiline_standalone_comment() {
     let data = HashBuilder::new();
-    let rv = rustache::render_text("Begin.\n{{!\nSomething's going on here...\n}}\nEnd.", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("Begin.\n{{!\nSomething's going on here...\n}}\nEnd.", data, &mut rv).unwrap();
 
-    assert_eq!("Begin.\nEnd.".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("Begin.\nEnd.".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Indented Multiline Standalone
@@ -143,9 +152,10 @@ fn test_spec_multiline_standalone_comment() {
 #[test]
 fn test_spec_indented_multiline_standalone_comment() {
     let data = HashBuilder::new();
-    let rv = rustache::render_text("Begin.\n{{!\n\tSomething's going on here...\n}}\nEnd.", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("Begin.\n{{!\n\tSomething's going on here...\n}}\nEnd.", data, &mut rv).unwrap();
 
-    assert_eq!("Begin.\nEnd.".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("Begin.\nEnd.".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Indented Inline
@@ -156,9 +166,10 @@ fn test_spec_indented_multiline_standalone_comment() {
 #[test]
 fn test_spec_indented_inline_comment() {
     let data = HashBuilder::new();
-    let rv = rustache::render_text("  12 {{! 34 }}\n", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("  12 {{! 34 }}\n", data, &mut rv).unwrap();
 
-    assert_eq!("  12 \n".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("  12 \n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Surrounding Whitespace
@@ -169,7 +180,8 @@ fn test_spec_indented_inline_comment() {
 #[test]
 fn test_spec_surrounding_whitespace_comment() {
     let data = HashBuilder::new();
-    let rv = rustache::render_text("12345 {{! Comment Block! }} 67890", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("12345 {{! Comment Block! }} 67890", data, &mut rv).unwrap();
 
-    assert_eq!("12345  67890".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("12345  67890".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }

--- a/tests/test_spec_comments.rs
+++ b/tests/test_spec_comments.rs
@@ -1,6 +1,6 @@
 extern crate rustache;
 
-use rustache::HashBuilder;
+use rustache::{HashBuilder, Render};
 use std::io::Cursor;
 
 // - name: Inline
@@ -12,7 +12,7 @@ use std::io::Cursor;
 fn test_spec_inline_comment() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("12345{{! Comment Block! }}67890", data, &mut rv).unwrap();
+    data.render("12345{{! Comment Block! }}67890", &mut rv).unwrap();
 
     assert_eq!("1234567890".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -31,7 +31,7 @@ fn test_spec_inline_comment() {
 fn test_spec_multiline_comment() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("12345{{!\nThis is a\nmulti-line comment...\n}}67890", data, &mut rv).unwrap();
+    data.render("12345{{!\nThis is a\nmulti-line comment...\n}}67890", &mut rv).unwrap();
 
     assert_eq!("1234567890".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -50,7 +50,7 @@ fn test_spec_multiline_comment() {
 fn test_spec_standalone_comment() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("Begin.\n{{! Comment Block! }}\nEnd.", data, &mut rv).unwrap();
+    data.render("Begin.\n{{! Comment Block! }}\nEnd.", &mut rv).unwrap();
 
     assert_eq!("Begin.\nEnd.".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -69,7 +69,7 @@ fn test_spec_standalone_comment() {
 fn test_spec_indented_standalone_comment() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("Begin.\n\t{{! Indented Comment Block! }}\nEnd.", data, &mut rv).unwrap();
+    data.render("Begin.\n\t{{! Indented Comment Block! }}\nEnd.", &mut rv).unwrap();
 
     assert_eq!("Begin.\nEnd.".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -83,7 +83,7 @@ fn test_spec_indented_standalone_comment() {
 fn test_spec_standalone_line_ending_comment() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("|\r\n{{! Standalone Comment }}\r\n|", data, &mut rv).unwrap();
+    data.render("|\r\n{{! Standalone Comment }}\r\n|", &mut rv).unwrap();
 
     assert_eq!("|\r\n|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -97,7 +97,7 @@ fn test_spec_standalone_line_ending_comment() {
 // fn test_spec_standalone_without_prev_line_comment() {
 //     let data = HashBuilder::new();
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("  {{! I'm Still Standalone }}\n!", data, &mut rv).unwrap();
+//     data.render("  {{! I'm Still Standalone }}\n!", &mut rv).unwrap();
 
 //     assert_eq!("!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -111,7 +111,7 @@ fn test_spec_standalone_line_ending_comment() {
 // fn test_spec_standalone_without_newline_comment() {
 //     let data = HashBuilder::new();
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("!\n  {{! I'm Still Standalone }}", data, &mut rv).unwrap();
+//     data.render("!\n  {{! I'm Still Standalone }}", &mut rv).unwrap();
 
 //     assert_eq!("!\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -132,7 +132,7 @@ fn test_spec_standalone_line_ending_comment() {
 fn test_spec_multiline_standalone_comment() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("Begin.\n{{!\nSomething's going on here...\n}}\nEnd.", data, &mut rv).unwrap();
+    data.render("Begin.\n{{!\nSomething's going on here...\n}}\nEnd.", &mut rv).unwrap();
 
     assert_eq!("Begin.\nEnd.".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -153,7 +153,7 @@ fn test_spec_multiline_standalone_comment() {
 fn test_spec_indented_multiline_standalone_comment() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("Begin.\n{{!\n\tSomething's going on here...\n}}\nEnd.", data, &mut rv).unwrap();
+    data.render("Begin.\n{{!\n\tSomething's going on here...\n}}\nEnd.", &mut rv).unwrap();
 
     assert_eq!("Begin.\nEnd.".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -167,7 +167,7 @@ fn test_spec_indented_multiline_standalone_comment() {
 fn test_spec_indented_inline_comment() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("  12 {{! 34 }}\n", data, &mut rv).unwrap();
+    data.render("  12 {{! 34 }}\n", &mut rv).unwrap();
 
     assert_eq!("  12 \n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -181,7 +181,7 @@ fn test_spec_indented_inline_comment() {
 fn test_spec_surrounding_whitespace_comment() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("12345 {{! Comment Block! }} 67890", data, &mut rv).unwrap();
+    data.render("12345 {{! Comment Block! }} 67890", &mut rv).unwrap();
 
     assert_eq!("12345  67890".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }

--- a/tests/test_spec_interpolation.rs
+++ b/tests/test_spec_interpolation.rs
@@ -1,6 +1,7 @@
 extern crate rustache;
 
 use rustache::HashBuilder;
+use std::io::Cursor;
 
 // - name: No Interpolation
 //   desc: Mustache-free templates should render as-is.
@@ -12,10 +13,10 @@ use rustache::HashBuilder;
 #[test]
 fn test_spec_interpolation_none() {
     let data = HashBuilder::new();
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("Hello from {Mustache}!", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("Hello from {Mustache}!", data);
-
-    assert_eq!("Hello from {Mustache}!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("Hello from {Mustache}!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Basic Interpolation
@@ -28,10 +29,10 @@ fn test_spec_interpolation_none() {
 #[test]
 fn test_spec_interpolation_basic() {
     let data = HashBuilder::new().insert("subject", "world");
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("Hello, {{subject}}!", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("Hello, {{subject}}!", data);
-
-    assert_eq!("Hello, world!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("Hello, world!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: HTML Escaping
@@ -44,10 +45,10 @@ fn test_spec_interpolation_basic() {
 #[test]
 fn test_spec_interpolation_html_escaping() {
     let data = HashBuilder::new().insert("forbidden", "& \" < >");
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("These characters should be HTML escaped: {{forbidden}}", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("These characters should be HTML escaped: {{forbidden}}", data);
-
-    assert_eq!("These characters should be HTML escaped: &amp; &quot; &lt; &gt;".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("These characters should be HTML escaped: &amp; &quot; &lt; &gt;".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Triple Mustache
@@ -60,10 +61,10 @@ fn test_spec_interpolation_html_escaping() {
 #[test]
 fn test_spec_interpolation_no_html_escaping_triple_mustache() {
     let data = HashBuilder::new().insert("forbidden", "& \" < >");
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("These characters should not be HTML escaped: {{{forbidden}}}", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("These characters should not be HTML escaped: {{{forbidden}}}", data);
-
-    assert_eq!("These characters should not be HTML escaped: & \" < >".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("These characters should not be HTML escaped: & \" < >".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Ampersand
@@ -76,10 +77,10 @@ fn test_spec_interpolation_no_html_escaping_triple_mustache() {
 #[test]
 fn test_spec_interpolation_no_html_escaping_ampersand() {
     let data = HashBuilder::new().insert("forbidden", "& \" < >");
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("These characters should not be HTML escaped: {{&forbidden}}", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("These characters should not be HTML escaped: {{&forbidden}}", data);
-
-    assert_eq!("These characters should not be HTML escaped: & \" < >".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("These characters should not be HTML escaped: & \" < >".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Basic Integer Interpolation
@@ -90,10 +91,10 @@ fn test_spec_interpolation_no_html_escaping_ampersand() {
 #[test]
 fn test_spec_interpolation_integer_basic() {
     let data = HashBuilder::new().insert("mph", 85);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{mph}} miles an hour!", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("{{mph}} miles an hour!", data);
-
-    assert_eq!("85 miles an hour!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("85 miles an hour!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Triple Mustache Integer Interpolation
@@ -104,10 +105,10 @@ fn test_spec_interpolation_integer_basic() {
 #[test]
 fn test_spec_interpolation_integer_triple_mustache() {
     let data = HashBuilder::new().insert("mph", 85);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{{mph}}} miles an hour!", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("{{{mph}}} miles an hour!", data);
-
-    assert_eq!("85 miles an hour!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("85 miles an hour!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Ampersand Integer Interpolation
@@ -118,10 +119,10 @@ fn test_spec_interpolation_integer_triple_mustache() {
 #[test]
 fn test_spec_interpolation_integer_ampersand() {
     let data = HashBuilder::new().insert("mph", 85);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{mph}} miles an hour!", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("{{mph}} miles an hour!", data);
-
-    assert_eq!("85 miles an hour!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("85 miles an hour!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Basic Decimal Interpolation
@@ -132,10 +133,10 @@ fn test_spec_interpolation_integer_ampersand() {
 #[test]
 fn test_spec_interpolation_float_basic() {
     let data = HashBuilder::new().insert("power", 1.210);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{power}} jiggawatts!", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("{{power}} jiggawatts!", data);
-
-    assert_eq!("1.21 jiggawatts!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("1.21 jiggawatts!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Triple Mustache Decimal Interpolation
@@ -146,10 +147,10 @@ fn test_spec_interpolation_float_basic() {
 #[test]
 fn test_spec_interpolation_float_triple_mustache() {
     let data = HashBuilder::new().insert("power", 1.210);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{{power}}} jiggawatts!", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("{{{power}}} jiggawatts!", data);
-
-    assert_eq!("1.21 jiggawatts!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("1.21 jiggawatts!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Ampersand Decimal Interpolation
@@ -160,10 +161,10 @@ fn test_spec_interpolation_float_triple_mustache() {
 #[test]
 fn test_spec_interpolation_float_ampersand() {
     let data = HashBuilder::new().insert("power", 1.210);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{&power}} jiggawatts!", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("{{&power}} jiggawatts!", data);
-
-    assert_eq!("1.21 jiggawatts!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("1.21 jiggawatts!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Basic Context Miss Interpolation
@@ -174,10 +175,10 @@ fn test_spec_interpolation_float_ampersand() {
 #[test]
 fn test_spec_interpolation_context_miss() {
     let data = HashBuilder::new();
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("I ({{cannot}}) be seen!", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("I ({{cannot}}) be seen!", data);
-
-    assert_eq!("I () be seen!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("I () be seen!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Triple Mustache Context Miss Interpolation
@@ -188,10 +189,10 @@ fn test_spec_interpolation_context_miss() {
 #[test]
 fn test_spec_interpolation_context_miss_triple_mustache() {
     let data = HashBuilder::new();
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("I ({{{cannot}}}) be seen!", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("I ({{{cannot}}}) be seen!", data);
-
-    assert_eq!("I () be seen!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("I () be seen!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Ampersand Context Miss Interpolation
@@ -202,10 +203,10 @@ fn test_spec_interpolation_context_miss_triple_mustache() {
 #[test]
 fn test_spec_interpolation_context_miss_ampersand() {
     let data = HashBuilder::new();
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("I ({{cannot}}) be seen!", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("I ({{cannot}}) be seen!", data);
-
-    assert_eq!("I () be seen!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("I () be seen!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Dotted Names - Basic Interpolation
@@ -216,10 +217,10 @@ fn test_spec_interpolation_context_miss_ampersand() {
 #[test]
 fn test_spec_interpolation_dotted_names_basic() {
     let data = HashBuilder::new().insert("person", HashBuilder::new().insert("name", "Joe"));
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("\"{{person.name}}\" == \"{{#person}}{{name}}{{/person}}\"", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("\"{{person.name}}\" == \"{{#person}}{{name}}{{/person}}\"", data);
-
-    assert_eq!("\"Joe\" == \"Joe\"".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("\"Joe\" == \"Joe\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Dotted Names - Triple Mustache Interpolation
@@ -233,10 +234,10 @@ fn test_spec_interpolation_dotted_names_triple_mustache() {
                 .insert("person", HashBuilder::new()
                     .insert("name", "Joe")
                 );
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("\"{{{person.name}}}\" == \"{{#person}}{{{name}}}{{/person}}\"", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("\"{{{person.name}}}\" == \"{{#person}}{{{name}}}{{/person}}\"", data);
-
-    assert_eq!("\"Joe\" == \"Joe\"".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("\"Joe\" == \"Joe\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Dotted Names - Ampersand Interpolation
@@ -250,10 +251,10 @@ fn test_spec_interpolation_dotted_names_ampersand() {
                 .insert("person", HashBuilder::new()
                     .insert("name", "Joe")
                 );
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("\"{{&person.name}}\" == \"{{#person}}{{&name}}{{/person}}\"", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("\"{{&person.name}}\" == \"{{#person}}{{&name}}{{/person}}\"", data);
-
-    assert_eq!("\"Joe\" == \"Joe\"".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("\"Joe\" == \"Joe\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Dotted Names - Arbitrary Depth
@@ -276,10 +277,10 @@ fn test_spec_interpolation_dotted_names_arbitrary_depth() {
                         )
                     )
                 );
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("\"{{a.b.c.d.e.name}}\" == \"Phil\"", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("\"{{a.b.c.d.e.name}}\" == \"Phil\"", data);
-
-    assert_eq!("\"Phil\" == \"Phil\"".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("\"Phil\" == \"Phil\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Dotted Names - Broken Chains
@@ -291,10 +292,10 @@ fn test_spec_interpolation_dotted_names_arbitrary_depth() {
 #[test]
 fn test_spec_interpolation_dotted_broken_chains() {
     let data = HashBuilder::new();
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("\"{{a.b.c}}\" == \"\"", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("\"{{a.b.c}}\" == \"\"", data);
-
-    assert_eq!("\"\" == \"\"".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("\"\" == \"\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Dotted Names - Broken Chain Resolution
@@ -313,10 +314,10 @@ fn test_spec_interpolation_dotted_broken_chain_resolution() {
                 .insert("c", HashBuilder::new()
                     .insert("name", "Jim")
                 );
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("\"{{a.b.c}}\" == \"\"", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("\"{{a.b.c}}\" == \"\"", data);
-
-    assert_eq!("\"\" == \"\"".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("\"\" == \"\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Dotted Names - Initial Resolution
@@ -349,10 +350,10 @@ fn test_spec_interpolation_dotted_initial_resolution() {
                         )
                     )
                 );
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("\"{{#a}}{{b.c.d.e.name}}{{/a}}\" == \"Phil\"", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("\"{{#a}}{{b.c.d.e.name}}{{/a}}\" == \"Phil\"", data);
-
-    assert_eq!("\"Phil\" == \"Phil\"".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("\"Phil\" == \"Phil\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Dotted Names - Context Precedence
@@ -373,10 +374,10 @@ fn test_spec_interpolation_dotted_context_precedence() {
                         .insert("name", "ERROR")
                     )
                 );
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{#a}}{{b.c}}{{/a}}", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("{{#a}}{{b.c}}{{/a}}", data);
-
-    assert_eq!("".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Interpolation - Surrounding Whitespace
@@ -387,10 +388,10 @@ fn test_spec_interpolation_dotted_context_precedence() {
 #[test]
 fn test_spec_interpolation_surrounding_whitespace_basic() {
     let data = HashBuilder::new().insert("string", "---");
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("| {{string}} |", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("| {{string}} |", data);
-
-    assert_eq!("| --- |".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("| --- |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Triple Mustache - Surrounding Whitespace
@@ -401,10 +402,10 @@ fn test_spec_interpolation_surrounding_whitespace_basic() {
 #[test]
 fn test_spec_interpolation_surrounding_whitespace_triple_mustache() {
     let data = HashBuilder::new().insert("string", "---");
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("| {{{string}}} |", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("| {{{string}}} |", data);
-
-    assert_eq!("| --- |".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("| --- |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Ampersand - Surrounding Whitespace
@@ -415,10 +416,10 @@ fn test_spec_interpolation_surrounding_whitespace_triple_mustache() {
 #[test]
 fn test_spec_interpolation_surrounding_whitespace_ampersand() {
     let data = HashBuilder::new().insert("string", "---");
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("| {{&string}} |", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("| {{&string}} |", data);
-
-    assert_eq!("| --- |".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("| --- |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Interpolation - Standalone
@@ -429,10 +430,10 @@ fn test_spec_interpolation_surrounding_whitespace_ampersand() {
 #[test]
 fn test_spec_interpolation_standalone_basic() {
     let data = HashBuilder::new().insert("string", "---");
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("  {{string}}\n", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("  {{string}}\n", data);
-
-    assert_eq!("  ---\n".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("  ---\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Triple Mustache - Standalone
@@ -443,10 +444,10 @@ fn test_spec_interpolation_standalone_basic() {
 #[test]
 fn test_spec_interpolation_standalone_triple_mustache() {
     let data = HashBuilder::new().insert("string", "---");
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("  {{{string}}}\n", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("  {{{string}}}\n", data);
-
-    assert_eq!("  ---\n".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("  ---\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Ampersand - Standalone
@@ -457,10 +458,10 @@ fn test_spec_interpolation_standalone_triple_mustache() {
 #[test]
 fn test_spec_interpolation_standalone_ampersand() {
     let data = HashBuilder::new().insert("string", "---");
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("  {{&string}}\n", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("  {{&string}}\n", data);
-
-    assert_eq!("  ---\n".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("  ---\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Interpolation With Padding
@@ -471,10 +472,10 @@ fn test_spec_interpolation_standalone_ampersand() {
 #[test]
 fn test_spec_interpolation_with_padding() {
   let data = HashBuilder::new().insert("string", "---");
+  let mut rv = Cursor::new(Vec::new());
+  rustache::render_text("|{{ string }}|", data, &mut rv).unwrap();
 
-  let rv = rustache::render_text("|{{ string }}|", data);
-
-  assert_eq!("|---|".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+  assert_eq!("|---|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Triple Mustache With Padding
@@ -485,10 +486,10 @@ fn test_spec_interpolation_with_padding() {
 #[test]
 fn test_spec_interpolation_triple_mustache_with_padding() {
     let data = HashBuilder::new().insert("string", "---");
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("|{{{ string }}}|", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("|{{{ string }}}|", data);
-
-    assert_eq!("|---|".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("|---|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Ampersand With Padding
@@ -499,9 +500,9 @@ fn test_spec_interpolation_triple_mustache_with_padding() {
 #[test]
 fn test_spec_interpolation_ampersand_with_padding() {
     let data = HashBuilder::new().insert("string", "---");
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("|{{& string }}|", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("|{{& string }}|", data);
-
-    assert_eq!("|---|".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("|---|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 

--- a/tests/test_spec_interpolation.rs
+++ b/tests/test_spec_interpolation.rs
@@ -1,6 +1,6 @@
 extern crate rustache;
 
-use rustache::HashBuilder;
+use rustache::{HashBuilder, Render};
 use std::io::Cursor;
 
 // - name: No Interpolation
@@ -14,7 +14,7 @@ use std::io::Cursor;
 fn test_spec_interpolation_none() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("Hello from {Mustache}!", data, &mut rv).unwrap();
+    data.render("Hello from {Mustache}!", &mut rv).unwrap();
 
     assert_eq!("Hello from {Mustache}!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -30,7 +30,7 @@ fn test_spec_interpolation_none() {
 fn test_spec_interpolation_basic() {
     let data = HashBuilder::new().insert("subject", "world");
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("Hello, {{subject}}!", data, &mut rv).unwrap();
+    data.render("Hello, {{subject}}!", &mut rv).unwrap();
 
     assert_eq!("Hello, world!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -46,7 +46,7 @@ fn test_spec_interpolation_basic() {
 fn test_spec_interpolation_html_escaping() {
     let data = HashBuilder::new().insert("forbidden", "& \" < >");
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("These characters should be HTML escaped: {{forbidden}}", data, &mut rv).unwrap();
+    data.render("These characters should be HTML escaped: {{forbidden}}", &mut rv).unwrap();
 
     assert_eq!("These characters should be HTML escaped: &amp; &quot; &lt; &gt;".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -62,7 +62,7 @@ fn test_spec_interpolation_html_escaping() {
 fn test_spec_interpolation_no_html_escaping_triple_mustache() {
     let data = HashBuilder::new().insert("forbidden", "& \" < >");
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("These characters should not be HTML escaped: {{{forbidden}}}", data, &mut rv).unwrap();
+    data.render("These characters should not be HTML escaped: {{{forbidden}}}", &mut rv).unwrap();
 
     assert_eq!("These characters should not be HTML escaped: & \" < >".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -78,7 +78,7 @@ fn test_spec_interpolation_no_html_escaping_triple_mustache() {
 fn test_spec_interpolation_no_html_escaping_ampersand() {
     let data = HashBuilder::new().insert("forbidden", "& \" < >");
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("These characters should not be HTML escaped: {{&forbidden}}", data, &mut rv).unwrap();
+    data.render("These characters should not be HTML escaped: {{&forbidden}}", &mut rv).unwrap();
 
     assert_eq!("These characters should not be HTML escaped: & \" < >".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -92,7 +92,7 @@ fn test_spec_interpolation_no_html_escaping_ampersand() {
 fn test_spec_interpolation_integer_basic() {
     let data = HashBuilder::new().insert("mph", 85);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{mph}} miles an hour!", data, &mut rv).unwrap();
+    data.render("{{mph}} miles an hour!", &mut rv).unwrap();
 
     assert_eq!("85 miles an hour!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -106,7 +106,7 @@ fn test_spec_interpolation_integer_basic() {
 fn test_spec_interpolation_integer_triple_mustache() {
     let data = HashBuilder::new().insert("mph", 85);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{{mph}}} miles an hour!", data, &mut rv).unwrap();
+    data.render("{{{mph}}} miles an hour!", &mut rv).unwrap();
 
     assert_eq!("85 miles an hour!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -120,7 +120,7 @@ fn test_spec_interpolation_integer_triple_mustache() {
 fn test_spec_interpolation_integer_ampersand() {
     let data = HashBuilder::new().insert("mph", 85);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{mph}} miles an hour!", data, &mut rv).unwrap();
+    data.render("{{mph}} miles an hour!", &mut rv).unwrap();
 
     assert_eq!("85 miles an hour!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -134,7 +134,7 @@ fn test_spec_interpolation_integer_ampersand() {
 fn test_spec_interpolation_float_basic() {
     let data = HashBuilder::new().insert("power", 1.210);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{power}} jiggawatts!", data, &mut rv).unwrap();
+    data.render("{{power}} jiggawatts!", &mut rv).unwrap();
 
     assert_eq!("1.21 jiggawatts!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -148,7 +148,7 @@ fn test_spec_interpolation_float_basic() {
 fn test_spec_interpolation_float_triple_mustache() {
     let data = HashBuilder::new().insert("power", 1.210);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{{power}}} jiggawatts!", data, &mut rv).unwrap();
+    data.render("{{{power}}} jiggawatts!", &mut rv).unwrap();
 
     assert_eq!("1.21 jiggawatts!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -162,7 +162,7 @@ fn test_spec_interpolation_float_triple_mustache() {
 fn test_spec_interpolation_float_ampersand() {
     let data = HashBuilder::new().insert("power", 1.210);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{&power}} jiggawatts!", data, &mut rv).unwrap();
+    data.render("{{&power}} jiggawatts!", &mut rv).unwrap();
 
     assert_eq!("1.21 jiggawatts!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -176,7 +176,7 @@ fn test_spec_interpolation_float_ampersand() {
 fn test_spec_interpolation_context_miss() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("I ({{cannot}}) be seen!", data, &mut rv).unwrap();
+    data.render("I ({{cannot}}) be seen!", &mut rv).unwrap();
 
     assert_eq!("I () be seen!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -190,7 +190,7 @@ fn test_spec_interpolation_context_miss() {
 fn test_spec_interpolation_context_miss_triple_mustache() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("I ({{{cannot}}}) be seen!", data, &mut rv).unwrap();
+    data.render("I ({{{cannot}}}) be seen!", &mut rv).unwrap();
 
     assert_eq!("I () be seen!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -204,7 +204,7 @@ fn test_spec_interpolation_context_miss_triple_mustache() {
 fn test_spec_interpolation_context_miss_ampersand() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("I ({{cannot}}) be seen!", data, &mut rv).unwrap();
+    data.render("I ({{cannot}}) be seen!", &mut rv).unwrap();
 
     assert_eq!("I () be seen!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -218,7 +218,7 @@ fn test_spec_interpolation_context_miss_ampersand() {
 fn test_spec_interpolation_dotted_names_basic() {
     let data = HashBuilder::new().insert("person", HashBuilder::new().insert("name", "Joe"));
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("\"{{person.name}}\" == \"{{#person}}{{name}}{{/person}}\"", data, &mut rv).unwrap();
+    data.render("\"{{person.name}}\" == \"{{#person}}{{name}}{{/person}}\"", &mut rv).unwrap();
 
     assert_eq!("\"Joe\" == \"Joe\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -235,7 +235,7 @@ fn test_spec_interpolation_dotted_names_triple_mustache() {
                     .insert("name", "Joe")
                 );
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("\"{{{person.name}}}\" == \"{{#person}}{{{name}}}{{/person}}\"", data, &mut rv).unwrap();
+    data.render("\"{{{person.name}}}\" == \"{{#person}}{{{name}}}{{/person}}\"", &mut rv).unwrap();
 
     assert_eq!("\"Joe\" == \"Joe\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -252,7 +252,7 @@ fn test_spec_interpolation_dotted_names_ampersand() {
                     .insert("name", "Joe")
                 );
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("\"{{&person.name}}\" == \"{{#person}}{{&name}}{{/person}}\"", data, &mut rv).unwrap();
+    data.render("\"{{&person.name}}\" == \"{{#person}}{{&name}}{{/person}}\"", &mut rv).unwrap();
 
     assert_eq!("\"Joe\" == \"Joe\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -278,7 +278,7 @@ fn test_spec_interpolation_dotted_names_arbitrary_depth() {
                     )
                 );
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("\"{{a.b.c.d.e.name}}\" == \"Phil\"", data, &mut rv).unwrap();
+    data.render("\"{{a.b.c.d.e.name}}\" == \"Phil\"", &mut rv).unwrap();
 
     assert_eq!("\"Phil\" == \"Phil\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -293,7 +293,7 @@ fn test_spec_interpolation_dotted_names_arbitrary_depth() {
 fn test_spec_interpolation_dotted_broken_chains() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("\"{{a.b.c}}\" == \"\"", data, &mut rv).unwrap();
+    data.render("\"{{a.b.c}}\" == \"\"", &mut rv).unwrap();
 
     assert_eq!("\"\" == \"\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -315,7 +315,7 @@ fn test_spec_interpolation_dotted_broken_chain_resolution() {
                     .insert("name", "Jim")
                 );
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("\"{{a.b.c}}\" == \"\"", data, &mut rv).unwrap();
+    data.render("\"{{a.b.c}}\" == \"\"", &mut rv).unwrap();
 
     assert_eq!("\"\" == \"\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -351,7 +351,7 @@ fn test_spec_interpolation_dotted_initial_resolution() {
                     )
                 );
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("\"{{#a}}{{b.c.d.e.name}}{{/a}}\" == \"Phil\"", data, &mut rv).unwrap();
+    data.render("\"{{#a}}{{b.c.d.e.name}}{{/a}}\" == \"Phil\"", &mut rv).unwrap();
 
     assert_eq!("\"Phil\" == \"Phil\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -375,7 +375,7 @@ fn test_spec_interpolation_dotted_context_precedence() {
                     )
                 );
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{#a}}{{b.c}}{{/a}}", data, &mut rv).unwrap();
+    data.render("{{#a}}{{b.c}}{{/a}}", &mut rv).unwrap();
 
     assert_eq!("".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -389,7 +389,7 @@ fn test_spec_interpolation_dotted_context_precedence() {
 fn test_spec_interpolation_surrounding_whitespace_basic() {
     let data = HashBuilder::new().insert("string", "---");
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("| {{string}} |", data, &mut rv).unwrap();
+    data.render("| {{string}} |", &mut rv).unwrap();
 
     assert_eq!("| --- |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -403,7 +403,7 @@ fn test_spec_interpolation_surrounding_whitespace_basic() {
 fn test_spec_interpolation_surrounding_whitespace_triple_mustache() {
     let data = HashBuilder::new().insert("string", "---");
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("| {{{string}}} |", data, &mut rv).unwrap();
+    data.render("| {{{string}}} |", &mut rv).unwrap();
 
     assert_eq!("| --- |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -417,7 +417,7 @@ fn test_spec_interpolation_surrounding_whitespace_triple_mustache() {
 fn test_spec_interpolation_surrounding_whitespace_ampersand() {
     let data = HashBuilder::new().insert("string", "---");
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("| {{&string}} |", data, &mut rv).unwrap();
+    data.render("| {{&string}} |", &mut rv).unwrap();
 
     assert_eq!("| --- |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -431,7 +431,7 @@ fn test_spec_interpolation_surrounding_whitespace_ampersand() {
 fn test_spec_interpolation_standalone_basic() {
     let data = HashBuilder::new().insert("string", "---");
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("  {{string}}\n", data, &mut rv).unwrap();
+    data.render("  {{string}}\n", &mut rv).unwrap();
 
     assert_eq!("  ---\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -445,7 +445,7 @@ fn test_spec_interpolation_standalone_basic() {
 fn test_spec_interpolation_standalone_triple_mustache() {
     let data = HashBuilder::new().insert("string", "---");
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("  {{{string}}}\n", data, &mut rv).unwrap();
+    data.render("  {{{string}}}\n", &mut rv).unwrap();
 
     assert_eq!("  ---\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -459,7 +459,7 @@ fn test_spec_interpolation_standalone_triple_mustache() {
 fn test_spec_interpolation_standalone_ampersand() {
     let data = HashBuilder::new().insert("string", "---");
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("  {{&string}}\n", data, &mut rv).unwrap();
+    data.render("  {{&string}}\n", &mut rv).unwrap();
 
     assert_eq!("  ---\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -473,7 +473,7 @@ fn test_spec_interpolation_standalone_ampersand() {
 fn test_spec_interpolation_with_padding() {
   let data = HashBuilder::new().insert("string", "---");
   let mut rv = Cursor::new(Vec::new());
-  rustache::render_text("|{{ string }}|", data, &mut rv).unwrap();
+  data.render("|{{ string }}|", &mut rv).unwrap();
 
   assert_eq!("|---|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -487,7 +487,7 @@ fn test_spec_interpolation_with_padding() {
 fn test_spec_interpolation_triple_mustache_with_padding() {
     let data = HashBuilder::new().insert("string", "---");
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("|{{{ string }}}|", data, &mut rv).unwrap();
+    data.render("|{{{ string }}}|", &mut rv).unwrap();
 
     assert_eq!("|---|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -501,7 +501,7 @@ fn test_spec_interpolation_triple_mustache_with_padding() {
 fn test_spec_interpolation_ampersand_with_padding() {
     let data = HashBuilder::new().insert("string", "---");
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("|{{& string }}|", data, &mut rv).unwrap();
+    data.render("|{{& string }}|", &mut rv).unwrap();
 
     assert_eq!("|---|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }

--- a/tests/test_spec_inverted.rs
+++ b/tests/test_spec_inverted.rs
@@ -1,6 +1,6 @@
 extern crate rustache;
 
-use rustache::{HashBuilder, VecBuilder};
+use rustache::{HashBuilder, Render, VecBuilder};
 use std::io::Cursor;
 
 // - name: Falsey
@@ -12,7 +12,7 @@ use std::io::Cursor;
 fn test_spec_inverted_falsy_bool() {
     let data = HashBuilder::new().insert("boolean", false);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{^boolean}}This should be rendered.{{/boolean}}", data, &mut rv).unwrap();
+    data.render("{{^boolean}}This should be rendered.{{/boolean}}", &mut rv).unwrap();
 
     assert_eq!("This should be rendered.".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -26,7 +26,7 @@ fn test_spec_inverted_falsy_bool() {
 fn test_spec_inverted_truthy_bool() {
     let data = HashBuilder::new().insert("boolean", true);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{^boolean}}This should not be rendered.{{/boolean}}", data, &mut rv).unwrap();
+    data.render("{{^boolean}}This should not be rendered.{{/boolean}}", &mut rv).unwrap();
 
     assert_eq!("".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -40,7 +40,7 @@ fn test_spec_inverted_truthy_bool() {
 fn test_spec_inverted_truthy_hash() {
     let data = HashBuilder::new().insert("context", HashBuilder::new().insert("name", "joe"));
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{^context}}Hi {{name}}.{{/context}}", data, &mut rv).unwrap();
+    data.render("{{^context}}Hi {{name}}.{{/context}}", &mut rv).unwrap();
 
     assert_eq!("".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -60,7 +60,7 @@ fn test_spec_inverted_truthy_vec() {
          )
     );
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{^list}}{{n}}{{/list}}", data, &mut rv).unwrap();
+    data.render("{{^list}}{{n}}{{/list}}", &mut rv).unwrap();
 
     assert_eq!("".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -74,7 +74,7 @@ fn test_spec_inverted_truthy_vec() {
 fn test_spec_inverted_falsy_on_empty_vec() {
     let data = HashBuilder::new().insert("list", VecBuilder::new());
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{^list}}Yay lists!{{/list}}", data, &mut rv).unwrap();
+    data.render("{{^list}}Yay lists!{{/list}}", &mut rv).unwrap();
 
     assert_eq!("Yay lists!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -98,7 +98,7 @@ fn test_spec_inverted_falsy_on_empty_vec() {
 // fn test_spec_inverted_multiple() {
 //     let data = HashBuilder::new().insert_bool("bool", false).insert("two", "second");
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("{{^bool}}\n* first\n{{/bool}}\n* {{two}}\n{{^bool}}\n* third\n{{/bool}}", data, &mut rv).unwrap();
+//     data.render("{{^bool}}\n* first\n{{/bool}}\n* {{two}}\n{{^bool}}\n* third\n{{/bool}}", &mut rv).unwrap();
 
 //     assert_eq!("* first\n* second\n* third".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -112,7 +112,7 @@ fn test_spec_inverted_falsy_on_empty_vec() {
 fn test_spec_inverted_nested_falsy() {
     let data = HashBuilder::new().insert("bool", false);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("| A {{^bool}}B {{^bool}}C{{/bool}} D{{/bool}} E |", data, &mut rv).unwrap();
+    data.render("| A {{^bool}}B {{^bool}}C{{/bool}} D{{/bool}} E |", &mut rv).unwrap();
 
     assert_eq!("| A B C D E |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -126,7 +126,7 @@ fn test_spec_inverted_nested_falsy() {
 fn test_spec_inverted_nested_truthy() {
     let data = HashBuilder::new().insert("bool", true);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("| A {{^bool}}B {{^bool}}C{{/bool}} D{{/bool}} E |", data, &mut rv).unwrap();
+    data.render("| A {{^bool}}B {{^bool}}C{{/bool}} D{{/bool}} E |", &mut rv).unwrap();
 
     assert_eq!("| A  E |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -140,7 +140,7 @@ fn test_spec_inverted_nested_truthy() {
 fn test_spec_inverted_missing_falsey() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("[{{^missing}}Cannot find key 'missing'!{{/missing}}]", data, &mut rv).unwrap();
+    data.render("[{{^missing}}Cannot find key 'missing'!{{/missing}}]", &mut rv).unwrap();
 
     assert_eq!("[Cannot find key 'missing'!]".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -161,7 +161,7 @@ fn test_spec_inverted_missing_falsey() {
 //                 })
 //         });
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("'{{^a.b.c}}Not Here{{/a.b.c}}' == ''", data)
+//     data.render("'{{^a.b.c}}Not Here{{/a.b.c}}' == ''", data)
 
 //     assert_eq!("'' == ''".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -180,7 +180,7 @@ fn test_spec_falsey_dotted_names_valid_inverted_section_tags() {
                 )
         );
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("'{{^a.b.c}}Not Here{{/a.b.c}}' == 'Not Here'", data, &mut rv).unwrap();
+    data.render("'{{^a.b.c}}Not Here{{/a.b.c}}' == 'Not Here'", &mut rv).unwrap();
 
     assert_eq!("'Not Here' == 'Not Here'".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -200,7 +200,7 @@ fn test_spec_falsey_dotted_names_valid_inverted_section_tags() {
 fn test_spec_inverted_surrounding_whitespace() {
     let data = HashBuilder::new().insert("boolean", false);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text(" | {{^boolean}}\t|\t{{/boolean}} | \n", data, &mut rv).unwrap();
+    data.render(" | {{^boolean}}\t|\t{{/boolean}} | \n", &mut rv).unwrap();
 
     assert_eq!(" | \t|\t | \n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -214,7 +214,7 @@ fn test_spec_inverted_surrounding_whitespace() {
 // fn test_spec_inverted_internal_whitespace() {
 //     let data = HashBuilder::new().insert("boolean", false);
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text(" | {{^boolean}} {{! Important Whitespace }}\n {{/boolean}} | \n", data, &mut rv).unwrap();
+//     data.render(" | {{^boolean}} {{! Important Whitespace }}\n {{/boolean}} | \n", &mut rv).unwrap();
 
 //     assert_eq!(" |  \n  | \n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -228,7 +228,7 @@ fn test_spec_inverted_surrounding_whitespace() {
 fn test_spec_inverted_indented_inline_sections() {
     let data = HashBuilder::new().insert("boolean", false);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text(" {{^boolean}}NO{{/boolean}}\n {{^boolean}}WAY{{/boolean}}\n", data, &mut rv).unwrap();
+    data.render(" {{^boolean}}NO{{/boolean}}\n {{^boolean}}WAY{{/boolean}}\n", &mut rv).unwrap();
 
     assert_eq!(" NO\n WAY\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -250,7 +250,7 @@ fn test_spec_inverted_indented_inline_sections() {
 // fn test_spec_inverted_standalone_lines() {
 //     let data = HashBuilder::new().insert("boolean", false);
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("| This Is\n{{^boolean}}\n|\n{{/boolean}}\n| A Line", data)
+//     data.render("| This Is\n{{^boolean}}\n|\n{{/boolean}}\n| A Line", data)
 
 //     assert_eq!("| This Is\n|\n| A Line".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -272,7 +272,7 @@ fn test_spec_inverted_indented_inline_sections() {
 // fn test_spec_inverted_standalone_indented_lines() {
 //     let data = HashBuilder::new().insert_bool("boolean", false);
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("| This Is\n  {{^boolean}}\n|\n  {{/boolean}}\n| A Line", data)
+//     data.render("| This Is\n  {{^boolean}}\n|\n  {{/boolean}}\n| A Line", data)
 
 //     assert_eq!("| This Is\n|\n| A Line".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -286,7 +286,7 @@ fn test_spec_inverted_indented_inline_sections() {
 // fn test_spec_inverted_standalone_rn_is_linebreak() {
 //     let data = HashBuilder::new().insert_bool("boolean", false);
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("|\r\n{{^boolean}}\r\n{{/boolean}}\r\n|", data)
+//     data.render("|\r\n{{^boolean}}\r\n{{/boolean}}\r\n|", data)
 
 //     assert_eq!("|\r\n|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -300,7 +300,7 @@ fn test_spec_inverted_indented_inline_sections() {
 // fn test_spec_inverted_standalone_without_previous_line() {
 //     let data = HashBuilder::new().insert_bool("boolean", false);
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("  {{^boolean}}\n^{{/boolean}}\n/", data, &mut rv).unwrap();
+//     data.render("  {{^boolean}}\n^{{/boolean}}\n/", &mut rv).unwrap();
 
 //     assert_eq!("^\n/".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -314,7 +314,7 @@ fn test_spec_inverted_indented_inline_sections() {
 // fn test_spec_inverted_standalone_without_newline() {
 //     let data = HashBuilder::new().insert_bool("boolean", false);
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("^{{^boolean}}\n/\n  {{/boolean}}", data, &mut rv).unwrap();
+//     data.render("^{{^boolean}}\n/\n  {{/boolean}}", &mut rv).unwrap();
 
 //     assert_eq!("^\n/\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -328,7 +328,7 @@ fn test_spec_inverted_indented_inline_sections() {
 fn test_spec_inverted_whitespace_insensitivity() {
     let data = HashBuilder::new().insert("boolean", false);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("|{{^ boolean }}={{/ boolean }}|", data, &mut rv).unwrap();
+    data.render("|{{^ boolean }}={{/ boolean }}|", &mut rv).unwrap();
 
     assert_eq!("|=|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }

--- a/tests/test_spec_inverted.rs
+++ b/tests/test_spec_inverted.rs
@@ -1,6 +1,7 @@
 extern crate rustache;
 
 use rustache::{HashBuilder, VecBuilder};
+use std::io::Cursor;
 
 // - name: Falsey
 //   desc: Falsey sections should have their contents rendered.
@@ -10,9 +11,10 @@ use rustache::{HashBuilder, VecBuilder};
 #[test]
 fn test_spec_inverted_falsy_bool() {
     let data = HashBuilder::new().insert("boolean", false);
-    let rv = rustache::render_text("{{^boolean}}This should be rendered.{{/boolean}}", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{^boolean}}This should be rendered.{{/boolean}}", data, &mut rv).unwrap();
 
-    assert_eq!("This should be rendered.".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("This should be rendered.".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Truthy
@@ -23,9 +25,10 @@ fn test_spec_inverted_falsy_bool() {
 #[test]
 fn test_spec_inverted_truthy_bool() {
     let data = HashBuilder::new().insert("boolean", true);
-    let rv = rustache::render_text("{{^boolean}}This should not be rendered.{{/boolean}}", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{^boolean}}This should not be rendered.{{/boolean}}", data, &mut rv).unwrap();
 
-    assert_eq!("".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Context
@@ -36,9 +39,10 @@ fn test_spec_inverted_truthy_bool() {
 #[test]
 fn test_spec_inverted_truthy_hash() {
     let data = HashBuilder::new().insert("context", HashBuilder::new().insert("name", "joe"));
-    let rv = rustache::render_text("{{^context}}Hi {{name}}.{{/context}}", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{^context}}Hi {{name}}.{{/context}}", data, &mut rv).unwrap();
 
-    assert_eq!("".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: List
@@ -55,9 +59,10 @@ fn test_spec_inverted_truthy_vec() {
            .insert("n", "3")
          )
     );
-    let rv = rustache::render_text("{{^list}}{{n}}{{/list}}", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{^list}}{{n}}{{/list}}", data, &mut rv).unwrap();
 
-    assert_eq!("".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Empty List
@@ -68,9 +73,10 @@ fn test_spec_inverted_truthy_vec() {
 #[test]
 fn test_spec_inverted_falsy_on_empty_vec() {
     let data = HashBuilder::new().insert("list", VecBuilder::new());
-    let rv = rustache::render_text("{{^list}}Yay lists!{{/list}}", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{^list}}Yay lists!{{/list}}", data, &mut rv).unwrap();
 
-    assert_eq!("Yay lists!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("Yay lists!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Doubled
@@ -91,9 +97,10 @@ fn test_spec_inverted_falsy_on_empty_vec() {
 // #[test]
 // fn test_spec_inverted_multiple() {
 //     let data = HashBuilder::new().insert_bool("bool", false).insert("two", "second");
-//     let rv = rustache::render_text("{{^bool}}\n* first\n{{/bool}}\n* {{two}}\n{{^bool}}\n* third\n{{/bool}}", data);
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("{{^bool}}\n* first\n{{/bool}}\n* {{two}}\n{{^bool}}\n* third\n{{/bool}}", data, &mut rv).unwrap();
 
-//     assert_eq!("* first\n* second\n* third".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("* first\n* second\n* third".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 // - name: Nested (Falsey)
@@ -103,11 +110,11 @@ fn test_spec_inverted_falsy_on_empty_vec() {
 //   expected: "| A B C D E |"
 #[test]
 fn test_spec_inverted_nested_falsy() {
-
     let data = HashBuilder::new().insert("bool", false);
-    let rv = rustache::render_text("| A {{^bool}}B {{^bool}}C{{/bool}} D{{/bool}} E |", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("| A {{^bool}}B {{^bool}}C{{/bool}} D{{/bool}} E |", data, &mut rv).unwrap();
 
-    assert_eq!("| A B C D E |".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("| A B C D E |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Nested (Truthy)
@@ -118,9 +125,10 @@ fn test_spec_inverted_nested_falsy() {
 #[test]
 fn test_spec_inverted_nested_truthy() {
     let data = HashBuilder::new().insert("bool", true);
-    let rv = rustache::render_text("| A {{^bool}}B {{^bool}}C{{/bool}} D{{/bool}} E |", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("| A {{^bool}}B {{^bool}}C{{/bool}} D{{/bool}} E |", data, &mut rv).unwrap();
 
-    assert_eq!("| A  E |".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("| A  E |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Context Misses
@@ -131,9 +139,10 @@ fn test_spec_inverted_nested_truthy() {
 #[test]
 fn test_spec_inverted_missing_falsey() {
     let data = HashBuilder::new();
-    let rv = rustache::render_text("[{{^missing}}Cannot find key 'missing'!{{/missing}}]", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("[{{^missing}}Cannot find key 'missing'!{{/missing}}]", data, &mut rv).unwrap();
 
-    assert_eq!("[Cannot find key 'missing'!]".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("[Cannot find key 'missing'!]".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Dotted Names - Truthy
@@ -151,9 +160,10 @@ fn test_spec_inverted_missing_falsey() {
 //                         .insert_bool("c", true)
 //                 })
 //         });
-//  let rv = rustache::render_text("'{{^a.b.c}}Not Here{{/a.b.c}}' == ''", data)
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("'{{^a.b.c}}Not Here{{/a.b.c}}' == ''", data)
 
-//     assert_eq!("'' == ''".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("'' == ''".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 // - name: Dotted Names - Falsey
@@ -169,9 +179,10 @@ fn test_spec_falsey_dotted_names_valid_inverted_section_tags() {
                         .insert("c", false)
                 )
         );
-    let rv = rustache::render_text("'{{^a.b.c}}Not Here{{/a.b.c}}' == 'Not Here'", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("'{{^a.b.c}}Not Here{{/a.b.c}}' == 'Not Here'", data, &mut rv).unwrap();
 
-    assert_eq!("'Not Here' == 'Not Here'".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("'Not Here' == 'Not Here'".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Dotted Names - Broken Chains
@@ -188,9 +199,10 @@ fn test_spec_falsey_dotted_names_valid_inverted_section_tags() {
 #[test]
 fn test_spec_inverted_surrounding_whitespace() {
     let data = HashBuilder::new().insert("boolean", false);
-    let rv = rustache::render_text(" | {{^boolean}}\t|\t{{/boolean}} | \n", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text(" | {{^boolean}}\t|\t{{/boolean}} | \n", data, &mut rv).unwrap();
 
-    assert_eq!(" | \t|\t | \n".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!(" | \t|\t | \n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Internal Whitespace
@@ -201,10 +213,10 @@ fn test_spec_inverted_surrounding_whitespace() {
 // #[test]
 // fn test_spec_inverted_internal_whitespace() {
 //     let data = HashBuilder::new().insert("boolean", false);
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text(" | {{^boolean}} {{! Important Whitespace }}\n {{/boolean}} | \n", data, &mut rv).unwrap();
 
-//     let rv = rustache::render_text(" | {{^boolean}} {{! Important Whitespace }}\n {{/boolean}} | \n", data);
-
-//     assert_eq!(" |  \n  | \n".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!(" |  \n  | \n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 // - name: Indented Inline Sections
@@ -215,9 +227,10 @@ fn test_spec_inverted_surrounding_whitespace() {
 #[test]
 fn test_spec_inverted_indented_inline_sections() {
     let data = HashBuilder::new().insert("boolean", false);
-    let rv = rustache::render_text(" {{^boolean}}NO{{/boolean}}\n {{^boolean}}WAY{{/boolean}}\n", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text(" {{^boolean}}NO{{/boolean}}\n {{^boolean}}WAY{{/boolean}}\n", data, &mut rv).unwrap();
 
-    assert_eq!(" NO\n WAY\n".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!(" NO\n WAY\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Standalone Lines
@@ -236,10 +249,10 @@ fn test_spec_inverted_indented_inline_sections() {
 // #[test]
 // fn test_spec_inverted_standalone_lines() {
 //     let data = HashBuilder::new().insert("boolean", false);
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("| This Is\n{{^boolean}}\n|\n{{/boolean}}\n| A Line", data)
 
-//     let rv = rustache::render_text("| This Is\n{{^boolean}}\n|\n{{/boolean}}\n| A Line", data)
-
-//     assert_eq!("| This Is\n|\n| A Line".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("| This Is\n|\n| A Line".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 // - name: Standalone Indented Lines
@@ -258,10 +271,10 @@ fn test_spec_inverted_indented_inline_sections() {
 // #[test]
 // fn test_spec_inverted_standalone_indented_lines() {
 //     let data = HashBuilder::new().insert_bool("boolean", false);
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("| This Is\n  {{^boolean}}\n|\n  {{/boolean}}\n| A Line", data)
 
-//     let rv = rustache::render_text("| This Is\n  {{^boolean}}\n|\n  {{/boolean}}\n| A Line", data)
-
-//     assert_eq!("| This Is\n|\n| A Line".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("| This Is\n|\n| A Line".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 // - name: Standalone Line Endings
@@ -272,10 +285,10 @@ fn test_spec_inverted_indented_inline_sections() {
 // #[test]
 // fn test_spec_inverted_standalone_rn_is_linebreak() {
 //     let data = HashBuilder::new().insert_bool("boolean", false);
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("|\r\n{{^boolean}}\r\n{{/boolean}}\r\n|", data)
 
-//     let rv = rustache::render_text("|\r\n{{^boolean}}\r\n{{/boolean}}\r\n|", data)
-
-//     assert_eq!("|\r\n|".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("|\r\n|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 // - name: Standalone Without Previous Line
@@ -286,10 +299,10 @@ fn test_spec_inverted_indented_inline_sections() {
 // #[test]
 // fn test_spec_inverted_standalone_without_previous_line() {
 //     let data = HashBuilder::new().insert_bool("boolean", false);
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("  {{^boolean}}\n^{{/boolean}}\n/", data, &mut rv).unwrap();
 
-//     let rv = rustache::render_text("  {{^boolean}}\n^{{/boolean}}\n/", data);
-
-//     assert_eq!("^\n/".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("^\n/".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 // - name: Standalone Without Newline
@@ -300,10 +313,10 @@ fn test_spec_inverted_indented_inline_sections() {
 // #[test]
 // fn test_spec_inverted_standalone_without_newline() {
 //     let data = HashBuilder::new().insert_bool("boolean", false);
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("^{{^boolean}}\n/\n  {{/boolean}}", data, &mut rv).unwrap();
 
-//     let rv = rustache::render_text("^{{^boolean}}\n/\n  {{/boolean}}", data);
-
-//     assert_eq!("^\n/\n".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("^\n/\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 // - name: Padding
@@ -314,9 +327,10 @@ fn test_spec_inverted_indented_inline_sections() {
 #[test]
 fn test_spec_inverted_whitespace_insensitivity() {
     let data = HashBuilder::new().insert("boolean", false);
-    let rv = rustache::render_text("|{{^ boolean }}={{/ boolean }}|", data);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("|{{^ boolean }}={{/ boolean }}|", data, &mut rv).unwrap();
 
-    assert_eq!("|=|".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("|=|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 

--- a/tests/test_spec_lambdas.rs
+++ b/tests/test_spec_lambdas.rs
@@ -1,6 +1,6 @@
 extern crate rustache;
 
-use rustache::HashBuilder;
+use rustache::{HashBuilder, Render};
 use std::io::Cursor;
 
 // - name: Interpolation
@@ -22,7 +22,7 @@ fn test_spec_lambdas_interpolation() {
                 .insert_lambda("lambda", &mut f);
     let mut rv = Cursor::new(Vec::new());
 
-    rustache::render_text("Hello, {{lambda}}!", data, &mut rv).unwrap();
+    data.render("Hello, {{lambda}}!", &mut rv).unwrap();
 
     assert_eq!("Hello, world!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -48,7 +48,7 @@ fn test_spec_lambdas_interpolation_expansion() {
                     .insert_lambda("lambda", &mut f);
     let mut rv = Cursor::new(Vec::new());
 
-    rustache::render_text("Hello, {{lambda}}!", data, &mut rv).unwrap();
+    data.render("Hello, {{lambda}}!", &mut rv).unwrap();
 
     assert_eq!("Hello, world!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -75,7 +75,7 @@ fn test_spec_lambdas_interpolation_expansion() {
 //                 });
 //     let mut rv = Cursor::new(Vec::new());
 
-//     rustache::render_text("{{= | | =}}\nHello, (|&lambda|)!", data, &mut rv).unwrap();
+//     data.render("{{= | | =}}\nHello, (|&lambda|)!", &mut rv).unwrap();
 
 //     assert_eq!("Hello, (|planet| => world)!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -103,7 +103,7 @@ fn test_spec_lambdas_interpolation_multiple_calls() {
                 .insert_lambda("lambda", &mut f);
     let mut rv = Cursor::new(Vec::new());
 
-    rustache::render_text("{{lambda}} == {{{lambda}}} == {{lambda}}", data, &mut rv).unwrap();
+    data.render("{{lambda}} == {{{lambda}}} == {{lambda}}", &mut rv).unwrap();
 
     assert_eq!("1 == 2 == 3".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -127,7 +127,7 @@ fn test_spec_lambdas_escaping() {
                 .insert_lambda("lambda", &mut f);
     let mut rv = Cursor::new(Vec::new());
 
-    rustache::render_text("<{{lambda}}{{{lambda}}}", data, &mut rv).unwrap();
+    data.render("<{{lambda}}{{{lambda}}}", &mut rv).unwrap();
 
     assert_eq!("<&gt;>".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -159,7 +159,7 @@ fn test_spec_lambdas_section() {
                 .insert_lambda("lambda", &mut f);
     let mut rv = Cursor::new(Vec::new());
 
-    rustache::render_text("<{{#lambda}}{{x}}{{/lambda}}>", data, &mut rv).unwrap();
+    data.render("<{{#lambda}}{{x}}{{/lambda}}>", &mut rv).unwrap();
 
     assert_eq!("<yes>".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -190,7 +190,7 @@ fn test_spec_lambdas_section_expansion() {
                 .insert_lambda("lambda", &mut f);
     let mut rv = Cursor::new(Vec::new());
 
-    rustache::render_text("<{{#lambda}}-{{/lambda}}>", data, &mut rv).unwrap();
+    data.render("<{{#lambda}}-{{/lambda}}>", &mut rv).unwrap();
 
     assert_eq!("<-Earth->".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -220,7 +220,7 @@ fn test_spec_lambdas_section_expansion() {
 //                 });
 //     let mut rv = Cursor::new(Vec::new());
 
-//     rustache::render_text_from_hb("{{= | | =}}<|#lambda|-|/lambda|>", data, &mut rv).unwrap();
+//     data.render_from_hb("{{= | | =}}<|#lambda|-|/lambda|>", &mut rv).unwrap();
 
 //     assert_eq!("<-{{planet}} => Earth->".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -249,7 +249,7 @@ fn test_spec_lambdas_section_multiple_calls() {
                 .insert_lambda("lambda", &mut f);
     let mut rv = Cursor::new(Vec::new());
 
-    rustache::render_text("{{#lambda}}FILE{{/lambda}} != {{#lambda}}LINE{{/lambda}}", data, &mut rv).unwrap();
+    data.render("{{#lambda}}FILE{{/lambda}} != {{#lambda}}LINE{{/lambda}}", &mut rv).unwrap();
 
     assert_eq!("__FILE__ != __LINE__".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -275,7 +275,7 @@ fn test_spec_lambdas_inverted_section() {
                 .insert_lambda("lambda", &mut f);
     let mut rv = Cursor::new(Vec::new());
 
-    rustache::render_text("<{{^lambda}}{{static}}{{/lambda}}>", data, &mut rv).unwrap();
+    data.render("<{{^lambda}}{{static}}{{/lambda}}>", &mut rv).unwrap();
 
     assert_eq!("<>".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }

--- a/tests/test_spec_lambdas.rs
+++ b/tests/test_spec_lambdas.rs
@@ -1,6 +1,7 @@
 extern crate rustache;
 
 use rustache::HashBuilder;
+use std::io::Cursor;
 
 // - name: Interpolation
 //     desc: A lambda's return value should be interpolated.
@@ -19,10 +20,11 @@ fn test_spec_lambdas_interpolation() {
     let mut f = |_| { "world".to_string() };
     let data = HashBuilder::new()
                 .insert_lambda("lambda", &mut f);
+    let mut rv = Cursor::new(Vec::new());
 
-    let rv = rustache::render_text("Hello, {{lambda}}!", data);
+    rustache::render_text("Hello, {{lambda}}!", data, &mut rv).unwrap();
 
-    assert_eq!("Hello, world!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("Hello, world!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Interpolation - Expansion
@@ -44,10 +46,11 @@ fn test_spec_lambdas_interpolation_expansion() {
     let data = HashBuilder::new()
                     .insert("planet", "world")
                     .insert_lambda("lambda", &mut f);
+    let mut rv = Cursor::new(Vec::new());
 
-    let rv = rustache::render_text("Hello, {{lambda}}!", data);
+    rustache::render_text("Hello, {{lambda}}!", data, &mut rv).unwrap();
 
-    assert_eq!("Hello, world!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("Hello, world!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Interpolation - Alternate Delimiters
@@ -68,12 +71,13 @@ fn test_spec_lambdas_interpolation_expansion() {
 //     let data = HashBuilder::new()
 //                 .insert("planet", "world")
 //                 .insert_lambda("lambda", |_| {
-//                     "|planet| => {{planet}}".to_string()               
+//                     "|planet| => {{planet}}".to_string()
 //                 });
+//     let mut rv = Cursor::new(Vec::new());
 
-//     let rv = rustache::render_text("{{= | | =}}\nHello, (|&lambda|)!", data);
+//     rustache::render_text("{{= | | =}}\nHello, (|&lambda|)!", data, &mut rv).unwrap();
 
-//     assert_eq!("Hello, (|planet| => world)!".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("Hello, (|planet| => world)!".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 //   - name: Interpolation - Multiple Calls
@@ -97,10 +101,11 @@ fn test_spec_lambdas_interpolation_multiple_calls() {
     };
     let data = HashBuilder::new()
                 .insert_lambda("lambda", &mut f);
+    let mut rv = Cursor::new(Vec::new());
 
-    let rv = rustache::render_text("{{lambda}} == {{{lambda}}} == {{lambda}}", data);
+    rustache::render_text("{{lambda}} == {{{lambda}}} == {{lambda}}", data, &mut rv).unwrap();
 
-    assert_eq!("1 == 2 == 3".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("1 == 2 == 3".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Escaping
@@ -120,10 +125,11 @@ fn test_spec_lambdas_escaping() {
     let mut f = |_| { ">".to_string() };
     let data = HashBuilder::new()
                 .insert_lambda("lambda", &mut f);
+    let mut rv = Cursor::new(Vec::new());
 
-    let rv = rustache::render_text("<{{lambda}}{{{lambda}}}", data);
+    rustache::render_text("<{{lambda}}{{{lambda}}}", data, &mut rv).unwrap();
 
-    assert_eq!("<&gt;>".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("<&gt;>".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Section
@@ -151,10 +157,11 @@ fn test_spec_lambdas_section() {
     let data = HashBuilder::new()
                 .insert("x", "Error!")
                 .insert_lambda("lambda", &mut f);
+    let mut rv = Cursor::new(Vec::new());
 
-    let rv = rustache::render_text("<{{#lambda}}{{x}}{{/lambda}}>", data);
+    rustache::render_text("<{{#lambda}}{{x}}{{/lambda}}>", data, &mut rv).unwrap();
 
-    assert_eq!("<yes>".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("<yes>".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Section - Expansion
@@ -181,10 +188,11 @@ fn test_spec_lambdas_section_expansion() {
     let data = HashBuilder::new()
                 .insert("planet", "Earth")
                 .insert_lambda("lambda", &mut f);
+    let mut rv = Cursor::new(Vec::new());
 
-    let rv = rustache::render_text("<{{#lambda}}-{{/lambda}}>", data);
+    rustache::render_text("<{{#lambda}}-{{/lambda}}>", data, &mut rv).unwrap();
 
-    assert_eq!("<-Earth->".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("<-Earth->".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Section - Alternate Delimiters
@@ -210,10 +218,11 @@ fn test_spec_lambdas_section_expansion() {
 //                     result.push_str(txt.as_slice());
 //                     result
 //                 });
+//     let mut rv = Cursor::new(Vec::new());
 
-//     let rv = rustache::render_text_from_hb("{{= | | =}}<|#lambda|-|/lambda|>", data);
+//     rustache::render_text_from_hb("{{= | | =}}<|#lambda|-|/lambda|>", data, &mut rv).unwrap();
 
-//     assert_eq!("<-{{planet}} => Earth->".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("<-{{planet}} => Earth->".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 //   - name: Section - Multiple Calls
@@ -238,10 +247,11 @@ fn test_spec_lambdas_section_multiple_calls() {
                 };
     let data = HashBuilder::new()
                 .insert_lambda("lambda", &mut f);
+    let mut rv = Cursor::new(Vec::new());
 
-    let rv = rustache::render_text("{{#lambda}}FILE{{/lambda}} != {{#lambda}}LINE{{/lambda}}", data);
+    rustache::render_text("{{#lambda}}FILE{{/lambda}} != {{#lambda}}LINE{{/lambda}}", data, &mut rv).unwrap();
 
-    assert_eq!("__FILE__ != __LINE__".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("__FILE__ != __LINE__".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Inverted Section
@@ -263,9 +273,10 @@ fn test_spec_lambdas_inverted_section() {
     let data = HashBuilder::new()
                 .insert("static", "static")
                 .insert_lambda("lambda", &mut f);
+    let mut rv = Cursor::new(Vec::new());
 
-    let rv = rustache::render_text("<{{^lambda}}{{static}}{{/lambda}}>", data);
+    rustache::render_text("<{{^lambda}}{{static}}{{/lambda}}>", data, &mut rv).unwrap();
 
-    assert_eq!("<>".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("<>".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 

--- a/tests/test_spec_partials.rs
+++ b/tests/test_spec_partials.rs
@@ -1,6 +1,7 @@
 extern crate rustache;
 
 use rustache::HashBuilder;
+use std::io::Cursor;
 
 //   - name: Basic Behavior
 //     desc: The greater-than operator should expand to the named partial.
@@ -11,10 +12,10 @@ use rustache::HashBuilder;
 #[test]
 fn test_spec_partials_basic_behavior() {
     let data = HashBuilder::new();
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("\"{{>test_data/test_spec_partials_basic}}\"", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("\"{{>test_data/test_spec_partials_basic}}\"", data);
-
-    assert_eq!("\"from partial\"".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("\"from partial\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Failed Lookup
@@ -26,10 +27,10 @@ fn test_spec_partials_basic_behavior() {
 #[test]
 fn test_spec_partials_failed_lookup() {
     let data = HashBuilder::new();
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("\"{{>text}}\"", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("\"{{>text}}\"", data);
-
-    assert_eq!("\"\"".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("\"\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Context
@@ -41,10 +42,10 @@ fn test_spec_partials_failed_lookup() {
 #[test]
 fn test_spec_partials_context() {
     let data = HashBuilder::new().insert("text", "content");
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("\"{{>test_data/test_spec_partials_context}}\"", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("\"{{>test_data/test_spec_partials_context}}\"", data);
-
-    assert_eq!("\"*content*\"".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("\"*content*\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Recursion
@@ -65,10 +66,11 @@ fn test_spec_partials_context() {
 //                          })
 //                     })
 //                 });
+//     let mut rv = Cursor::new(Vec::new());
 
-//     let rv = rustache::render_text("{{>test_data/test_spec_partials_recursion}}", data);
+//     rustache::render_text("{{>test_data/test_spec_partials_recursion}}", data, &mut rv).unwrap();
 
-//     assert_eq!("X<Y<>>".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("X<Y<>>".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 //   - name: Surrounding Whitespace
@@ -80,10 +82,10 @@ fn test_spec_partials_context() {
 #[test]
 fn test_spec_partials_surrounding_whitespace() {
     let data = HashBuilder::new();
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("| {{>test_data/test_spec_partials_whitespace}} |", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("| {{>test_data/test_spec_partials_whitespace}} |", data);
-
-    assert_eq!("| \t|\t |".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("| \t|\t |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Inline Indentation
@@ -95,10 +97,10 @@ fn test_spec_partials_surrounding_whitespace() {
 #[test]
 fn test_spec_partials_inline_indentation() {
     let data = HashBuilder::new().insert("data", "|");
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("  {{data}}  {{> test_data/test_spec_partials_inline_indentation}}\n", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("  {{data}}  {{> test_data/test_spec_partials_inline_indentation}}\n", data);
-
-    assert_eq!("  |  >\n>\n".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("  |  >\n>\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Standalone Line Endings
@@ -110,10 +112,10 @@ fn test_spec_partials_inline_indentation() {
 // #[test]
 // fn test_spec_partials_standalone_line_endings() {
 //     let data = HashBuilder::new();
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("|\r\n{{>partial}}\r\n|", data, &mut rv).unwrap();
 
-//     let rv = rustache::render_text("|\r\n{{>partial}}\r\n|", data);
-
-//     assert_eq!("|\r\n>|".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("|\r\n>|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 //   - name: Standalone Without Previous Line
@@ -125,10 +127,10 @@ fn test_spec_partials_inline_indentation() {
 #[test]
 fn test_spec_partials_standalone_without_previous_line() {
     let data = HashBuilder::new();
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("  {{>test_data/test_spec_partials_standalone_without_previous_line}}\n>", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("  {{>test_data/test_spec_partials_standalone_without_previous_line}}\n>", data);
-
-    assert_eq!("  >\n>\n>".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("  >\n>\n>".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Standalone Without Newline
@@ -140,10 +142,10 @@ fn test_spec_partials_standalone_without_previous_line() {
 #[test]
 fn test_spec_partials_standalone_without_newline() {
     let data = HashBuilder::new();
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text(">\n  {{>test_data/test_spec_partials_standalone_without_newline}}", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text(">\n  {{>test_data/test_spec_partials_standalone_without_newline}}", data);
-
-    assert_eq!(">\n  >\n>".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!(">\n  >\n>".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Standalone Indentation
@@ -169,9 +171,10 @@ fn test_spec_partials_standalone_without_newline() {
 // fn test_spec_partials_standalone_indentation() {
 //     let data = HashBuilder::new().insert("content", "<\n->");
 
-//     let rv = rustache::render_text("|\n\\\n {{>test_data/test_spec_partials_standalone_indentation}}\n/\n", data);
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("|\n\\\n {{>test_data/test_spec_partials_standalone_indentation}}\n/\n", data, &mut rv).unwrap();
 
-//     assert_eq!("|\n\\\n |\n <\n ->\n |\n/\n".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("|\n\\\n |\n <\n ->\n |\n/\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 //   - name: Padding Whitespace
@@ -184,8 +187,8 @@ fn test_spec_partials_standalone_without_newline() {
 fn test_spec_partials_padding_whitespace() {
     let data = HashBuilder::new()
                 .insert("boolean", true);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("|{{> test_data/test_spec_partials_padding_whitespace }}|", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("|{{> test_data/test_spec_partials_padding_whitespace }}|", data);
-
-    assert_eq!("|[]|".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("|[]|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }

--- a/tests/test_spec_partials.rs
+++ b/tests/test_spec_partials.rs
@@ -1,6 +1,6 @@
 extern crate rustache;
 
-use rustache::HashBuilder;
+use rustache::{HashBuilder, Render};
 use std::io::Cursor;
 
 //   - name: Basic Behavior
@@ -13,7 +13,7 @@ use std::io::Cursor;
 fn test_spec_partials_basic_behavior() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("\"{{>test_data/test_spec_partials_basic}}\"", data, &mut rv).unwrap();
+    data.render("\"{{>test_data/test_spec_partials_basic}}\"", &mut rv).unwrap();
 
     assert_eq!("\"from partial\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -28,7 +28,7 @@ fn test_spec_partials_basic_behavior() {
 fn test_spec_partials_failed_lookup() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("\"{{>text}}\"", data, &mut rv).unwrap();
+    data.render("\"{{>text}}\"", &mut rv).unwrap();
 
     assert_eq!("\"\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -43,7 +43,7 @@ fn test_spec_partials_failed_lookup() {
 fn test_spec_partials_context() {
     let data = HashBuilder::new().insert("text", "content");
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("\"{{>test_data/test_spec_partials_context}}\"", data, &mut rv).unwrap();
+    data.render("\"{{>test_data/test_spec_partials_context}}\"", &mut rv).unwrap();
 
     assert_eq!("\"*content*\"".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -68,7 +68,7 @@ fn test_spec_partials_context() {
 //                 });
 //     let mut rv = Cursor::new(Vec::new());
 
-//     rustache::render_text("{{>test_data/test_spec_partials_recursion}}", data, &mut rv).unwrap();
+//     data.render("{{>test_data/test_spec_partials_recursion}}", &mut rv).unwrap();
 
 //     assert_eq!("X<Y<>>".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -83,7 +83,7 @@ fn test_spec_partials_context() {
 fn test_spec_partials_surrounding_whitespace() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("| {{>test_data/test_spec_partials_whitespace}} |", data, &mut rv).unwrap();
+    data.render("| {{>test_data/test_spec_partials_whitespace}} |", &mut rv).unwrap();
 
     assert_eq!("| \t|\t |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -98,7 +98,7 @@ fn test_spec_partials_surrounding_whitespace() {
 fn test_spec_partials_inline_indentation() {
     let data = HashBuilder::new().insert("data", "|");
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("  {{data}}  {{> test_data/test_spec_partials_inline_indentation}}\n", data, &mut rv).unwrap();
+    data.render("  {{data}}  {{> test_data/test_spec_partials_inline_indentation}}\n", &mut rv).unwrap();
 
     assert_eq!("  |  >\n>\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -113,7 +113,7 @@ fn test_spec_partials_inline_indentation() {
 // fn test_spec_partials_standalone_line_endings() {
 //     let data = HashBuilder::new();
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("|\r\n{{>partial}}\r\n|", data, &mut rv).unwrap();
+//     data.render("|\r\n{{>partial}}\r\n|", &mut rv).unwrap();
 
 //     assert_eq!("|\r\n>|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -128,7 +128,7 @@ fn test_spec_partials_inline_indentation() {
 fn test_spec_partials_standalone_without_previous_line() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("  {{>test_data/test_spec_partials_standalone_without_previous_line}}\n>", data, &mut rv).unwrap();
+    data.render("  {{>test_data/test_spec_partials_standalone_without_previous_line}}\n>", &mut rv).unwrap();
 
     assert_eq!("  >\n>\n>".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -143,7 +143,7 @@ fn test_spec_partials_standalone_without_previous_line() {
 fn test_spec_partials_standalone_without_newline() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text(">\n  {{>test_data/test_spec_partials_standalone_without_newline}}", data, &mut rv).unwrap();
+    data.render(">\n  {{>test_data/test_spec_partials_standalone_without_newline}}", &mut rv).unwrap();
 
     assert_eq!(">\n  >\n>".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -172,7 +172,7 @@ fn test_spec_partials_standalone_without_newline() {
 //     let data = HashBuilder::new().insert("content", "<\n->");
 
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("|\n\\\n {{>test_data/test_spec_partials_standalone_indentation}}\n/\n", data, &mut rv).unwrap();
+//     data.render("|\n\\\n {{>test_data/test_spec_partials_standalone_indentation}}\n/\n", &mut rv).unwrap();
 
 //     assert_eq!("|\n\\\n |\n <\n ->\n |\n/\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -188,7 +188,7 @@ fn test_spec_partials_padding_whitespace() {
     let data = HashBuilder::new()
                 .insert("boolean", true);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("|{{> test_data/test_spec_partials_padding_whitespace }}|", data, &mut rv).unwrap();
+    data.render("|{{> test_data/test_spec_partials_padding_whitespace }}|", &mut rv).unwrap();
 
     assert_eq!("|[]|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }

--- a/tests/test_spec_sections.rs
+++ b/tests/test_spec_sections.rs
@@ -1,6 +1,7 @@
 extern crate rustache;
 
 use rustache::{HashBuilder, VecBuilder};
+use std::io::Cursor;
 
 // - name: Truthy
 //   desc: Truthy sections should have their contents rendered.
@@ -11,10 +12,10 @@ use rustache::{HashBuilder, VecBuilder};
 fn test_spec_sections_truthy_should_render_contents() {
     let data = HashBuilder::new()
         .insert("boolean", true);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{#boolean}}This should be rendered.{{/boolean}}", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("{{#boolean}}This should be rendered.{{/boolean}}", data);
-
-    assert_eq!("This should be rendered.".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("This should be rendered.".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Falsy
@@ -26,10 +27,10 @@ fn test_spec_sections_truthy_should_render_contents() {
 fn test_spec_sections_falsy_should_not_render_contents() {
     let data = HashBuilder::new()
         .insert("boolean", false);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{#boolean}}This should not be rendered.{{/boolean}}", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("{{#boolean}}This should not be rendered.{{/boolean}}", data);
-
-    assert_eq!("".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Context
@@ -43,10 +44,10 @@ fn test_spec_sections_objects_and_hashes_should_be_pushed_onto_context_stack() {
         .insert("context", HashBuilder::new()
                 .insert("name", "Joe")
         );
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{#context}}Hi {{name}}.{{/context}}", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("{{#context}}Hi {{name}}.{{/context}}", data);
-
-    assert_eq!("Hi Joe.".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("Hi Joe.".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 // - name: Deeply Nested Contexts
@@ -110,8 +111,8 @@ fn test_spec_sections_objects_and_hashes_should_be_pushed_onto_context_stack() {
 //             builder
 //                 .insert_int("five", 5)
 //         });
-
-//     let rv = rustache::render_text("{{#a}}
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("{{#a}}
 //                            {{one}}
 //                            {{#b}}
 //                            {{one}}{{two}}{{one}}
@@ -141,7 +142,7 @@ fn test_spec_sections_objects_and_hashes_should_be_pushed_onto_context_stack() {
 //                 12321
 //                 121
 //                 1".to_string(),
-//                 String::from_utf8(rv.unwrap().into_inner()).unwrap()
+//                 String::from_utf8(rv.into_inner()).unwrap()
 //               );
 // }
 
@@ -164,10 +165,10 @@ fn test_spec_sections_list_items_are_iterated() {
                         .insert("item".to_string(), "3".to_string())
                 )
         );
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{#list}}{{item}}{{/list}}", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("{{#list}}{{item}}{{/list}}", data);
-
-    assert_eq!("123".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("123".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Empty List
@@ -179,10 +180,10 @@ fn test_spec_sections_list_items_are_iterated() {
 fn test_spec_sections_empty_lists_behave_like_falsy_values() {
     let data = HashBuilder::new()
         .insert("list", VecBuilder::new());
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("{{#list}}Yay lists!{{/list}}", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("{{#list}}Yay lists!{{/list}}", data);
-
-    assert_eq!("".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Doubled
@@ -205,8 +206,8 @@ fn test_spec_sections_empty_lists_behave_like_falsy_values() {
 //     let data = HashBuilder::new()
 //         .insert_bool("bool", true)
 //         .insert("two", "second");
-
-//     let rv = rustache::render_text("{{#bool}}
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("{{#bool}}
 //                            * first
 //                            {{/bool}}
 //                            * {{two}}
@@ -220,7 +221,7 @@ fn test_spec_sections_empty_lists_behave_like_falsy_values() {
 //     assert_eq!("* first
 //                 * second
 //                 * third".to_string(),
-//                 String::from_utf8(rv.unwrap().into_inner()).unwrap()
+//                 String::from_utf8(rv.into_inner()).unwrap()
 //               );
 // }
 
@@ -233,10 +234,10 @@ fn test_spec_sections_empty_lists_behave_like_falsy_values() {
 fn test_spec_sections_nested_truthy_contents_render() {
     let data = HashBuilder::new()
         .insert("bool", true);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("| A {{#bool}}B {{#bool}}C{{/bool}} D{{/bool}} E |", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("| A {{#bool}}B {{#bool}}C{{/bool}} D{{/bool}} E |", data);
-
-    assert_eq!("| A B C D E |".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("| A B C D E |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Nested (Falsy)
@@ -248,10 +249,10 @@ fn test_spec_sections_nested_truthy_contents_render() {
 fn test_spec_sections_nested_falsy_contents_do_not_render() {
     let data = HashBuilder::new()
         .insert("bool", false);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("| A {{#bool}}B {{#bool}}C{{/bool}} D{{/bool}} E |", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("| A {{#bool}}B {{#bool}}C{{/bool}} D{{/bool}} E |", data);
-
-    assert_eq!("| A  E |".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("| A  E |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Context Misses
@@ -262,10 +263,10 @@ fn test_spec_sections_nested_falsy_contents_do_not_render() {
 #[test]
 fn test_spec_sections_failed_context_lookups_are_falsy() {
     let data = HashBuilder::new();
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("[{{#missing}}Found key 'missing'!{{/missing}}]", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("[{{#missing}}Found key 'missing'!{{/missing}}]", data);
-
-    assert_eq!("[]".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("[]".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Implicit Iterator - String
@@ -285,10 +286,10 @@ fn test_spec_sections_failed_context_lookups_are_falsy() {
 //                 .push_string("d")
 //                 .push_string("e")
 //         });
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("{{#list}}({{.}}){{/list}}", data, &mut rv).unwrap();
 
-// let rv = rustache::render_text("{{#list}}({{.}}){{/list}}", data);
-
-//     assert_eq!("(a)(b)(c)(d)(e)".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("(a)(b)(c)(d)(e)".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 //   - name: Implicit Iterator - Integer
@@ -308,10 +309,10 @@ fn test_spec_sections_failed_context_lookups_are_falsy() {
 //                 .push_int(4)
 //                 .push_int(5)
 //         });
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("{{#list}}({{.}}){{/list}}", data, &mut rv).unwrap();
 
-//     let rv = rustache::render_text("{{#list}}({{.}}){{/list}}", data);
-
-//     assert_eq!("(1)(2)(3)(4)(5)".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("(1)(2)(3)(4)(5)".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 //   - name: Implicit Iterator - Decimal
@@ -331,10 +332,10 @@ fn test_spec_sections_failed_context_lookups_are_falsy() {
 //                 .push_float(4.40)
 //                 .push_float(5.50)
 //         });
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("{{#list}}({{.}}){{/list}}", data, &mut rv).unwrap();
 
-//     let rv = rustache::render_text("{{#list}}({{.}}){{/list}}", data);
-
-//     assert_eq!("(1.1)(2.2)(3.3)(4.4)(5.5)".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("(1.1)(2.2)(3.3)(4.4)(5.5)".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 //   - name: Dotted Names - Truthy
@@ -352,10 +353,10 @@ fn test_spec_sections_failed_context_lookups_are_falsy() {
 //                         .insert_bool("c", true)
 //             })
 //         });
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("'{{#a.b.c}}Here{{/a.b.c}}' == 'Here'", data, &mut rv).unwrap();
 
-//     let rv = rustache::render_text("'{{#a.b.c}}Here{{/a.b.c}}' == 'Here'", data);
-
-//     assert_eq!("'Here' == 'Here'".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("'Here' == 'Here'".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 //   - name: Dotted Names - Falsy
@@ -371,10 +372,10 @@ fn test_spec_sections_falsy_dotted_names_are_not_valid_section_tags() {
                         .insert("c", false)
             )
         );
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("'{{#a.b.c}}Here{{/a.b.c}}' == ''", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("'{{#a.b.c}}Here{{/a.b.c}}' == ''", data);
-
-    assert_eq!("'' == ''".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("'' == ''".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Dotted Names - Broken Chains
@@ -386,10 +387,10 @@ fn test_spec_sections_falsy_dotted_names_are_not_valid_section_tags() {
 fn test_spec_sections_unresolved_dotted_names_are_not_valid_section_tags() {
     let data = HashBuilder::new()
         .insert("a", HashBuilder::new());
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("'{{#a.b.c}}Here{{/a.b.c}}' == ''", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("'{{#a.b.c}}Here{{/a.b.c}}' == ''", data);
-
-    assert_eq!("'' == ''".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("'' == ''".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Surrounding Whitespace
@@ -401,10 +402,10 @@ fn test_spec_sections_unresolved_dotted_names_are_not_valid_section_tags() {
 fn test_spec_sections_do_not_alter_surrounding_whitespace() {
     let data = HashBuilder::new()
         .insert("boolean", true);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text(" | {{#boolean}}\t|\t{{/boolean}} | \n", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text(" | {{#boolean}}\t|\t{{/boolean}} | \n", data);
-
-    assert_eq!(" | \t|\t | \n".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!(" | \t|\t | \n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Internal Whitespace
@@ -416,10 +417,10 @@ fn test_spec_sections_do_not_alter_surrounding_whitespace() {
 // fn test_spec_sections_do_not_alter_internal_whitespace() {
 //     let data = HashBuilder::new()
 //         .insert_bool("boolean", true);
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text(" | {{#boolean}} {{! Important Whitespace }}\n {{/boolean}} | \n", data, &mut rv).unwrap();
 
-//     let rv = rustache::render_text(" | {{#boolean}} {{! Important Whitespace }}\n {{/boolean}} | \n", data);
-
-//     assert_eq!(" |  \n  | \n".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!(" |  \n  | \n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 //   - name: Indented Inline Sections
@@ -431,10 +432,10 @@ fn test_spec_sections_do_not_alter_surrounding_whitespace() {
 fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace() {
     let data = HashBuilder::new()
         .insert("boolean", true);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text(" {{#boolean}}YES{{/boolean}}\n {{#boolean}}GOOD{{/boolean}}\n", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text(" {{#boolean}}YES{{/boolean}}\n {{#boolean}}GOOD{{/boolean}}\n", data);
-
-    assert_eq!(" YES\n GOOD\n".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!(" YES\n GOOD\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
 
 //   - name: Standalone Lines
@@ -454,8 +455,8 @@ fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace()
 // fn test_spec_sections_standalone_lines_are_removed_from_template() {
 //     let data = HashBuilder::new()
 //         .insert("boolean", true);
-
-//     let rv = rustache::render_text("|
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("|
 //                            | This Is
 //                            {{#boolean}}
 //                            |
@@ -469,7 +470,7 @@ fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace()
 //                 | This Is
 //                 |
 //                 | A Line".to_string(),
-//                 String::from_utf8(rv.unwrap().into_inner()).unwrap()
+//                 String::from_utf8(rv.into_inner()).unwrap()
 //               );
 // }
 
@@ -490,22 +491,22 @@ fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace()
 // fn test_spec_sections_indented_standalone_lines_are_removed_from_template() {
 //     let data = HashBuilder::new()
 //         .insert_bool("boolean", true);
-
-//     let rv = rustache::render_text("|
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("|
 //                            | This Is
 //                              {{#boolean}}
 //                            |
 //                              {{/boolean}}
 //                            | A Line", 
 //                            &data, 
-//                            &mut w
-//                          );
+//                            &mut rv
+//                          ).unwrap();
 
 //     assert_eq!("|
 //                 | This Is
 //                 |
 //                 | A Line".to_string(),
-//                 String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//                 String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 //   - name: Standalone Line Endings
@@ -517,10 +518,10 @@ fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace()
 // fn test_spec_sections_newline_standalone_tags() {
 //     let data = HashBuilder::new()
 //         .insert_bool("boolean", true);
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("|\r\n{{#boolean}}\r\n{{/boolean}}\r\n|", data, &mut rv).unwrap();
 
-//     let rv = rustache::render_text("|\r\n{{#boolean}}\r\n{{/boolean}}\r\n|", data);
-
-//     assert_eq!("|\r\n|".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("|\r\n|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 //   - name: Standalone Without Previous Line
@@ -532,10 +533,10 @@ fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace()
 // fn test_spec_sections_standalone_tags_do_not_require_preceding_newline() {
 //     let data = HashBuilder::new()
 //         .insert_bool("boolean", true);
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("  {{#boolean}}\n#{{/boolean}}\n/", data, &mut rv).unwrap();
 
-//     let rv = rustache::render_text("  {{#boolean}}\n#{{/boolean}}\n/", data);
-
-//     assert_eq!("#\n/".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("#\n/".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 //   - name: Standalone Without Newline
@@ -547,10 +548,10 @@ fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace()
 // fn test_spec_sections_standalone_tags_do_not_require_following_newline() {
 //     let data = HashBuilder::new()
 //         .insert_bool("boolean", true);
+//     let mut rv = Cursor::new(Vec::new());
+//     rustache::render_text("#{{#boolean}}\n/\n  {{/boolean}}", data, &mut rv).unwrap();
 
-//     let rv = rustache::render_text("#{{#boolean}}\n/\n  {{/boolean}}", data);
-
-//     assert_eq!("#\n/\n".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+//     assert_eq!("#\n/\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
 
 //   - name: Padding
@@ -562,8 +563,8 @@ fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace()
 fn test_spec_sections_superfluous_tag_whitespace_is_ignored() {
     let data = HashBuilder::new()
         .insert("boolean", true);
+    let mut rv = Cursor::new(Vec::new());
+    rustache::render_text("|{{# boolean }}={{/ boolean }}|", data, &mut rv).unwrap();
 
-    let rv = rustache::render_text("|{{# boolean }}={{/ boolean }}|", data);
-
-    assert_eq!("|=|".to_string(), String::from_utf8(rv.unwrap().into_inner()).unwrap());
+    assert_eq!("|=|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }

--- a/tests/test_spec_sections.rs
+++ b/tests/test_spec_sections.rs
@@ -1,6 +1,6 @@
 extern crate rustache;
 
-use rustache::{HashBuilder, VecBuilder};
+use rustache::{HashBuilder, Render, VecBuilder};
 use std::io::Cursor;
 
 // - name: Truthy
@@ -13,7 +13,7 @@ fn test_spec_sections_truthy_should_render_contents() {
     let data = HashBuilder::new()
         .insert("boolean", true);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{#boolean}}This should be rendered.{{/boolean}}", data, &mut rv).unwrap();
+    data.render("{{#boolean}}This should be rendered.{{/boolean}}", &mut rv).unwrap();
 
     assert_eq!("This should be rendered.".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -28,7 +28,7 @@ fn test_spec_sections_falsy_should_not_render_contents() {
     let data = HashBuilder::new()
         .insert("boolean", false);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{#boolean}}This should not be rendered.{{/boolean}}", data, &mut rv).unwrap();
+    data.render("{{#boolean}}This should not be rendered.{{/boolean}}", &mut rv).unwrap();
 
     assert_eq!("".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -45,7 +45,7 @@ fn test_spec_sections_objects_and_hashes_should_be_pushed_onto_context_stack() {
                 .insert("name", "Joe")
         );
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{#context}}Hi {{name}}.{{/context}}", data, &mut rv).unwrap();
+    data.render("{{#context}}Hi {{name}}.{{/context}}", &mut rv).unwrap();
 
     assert_eq!("Hi Joe.".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -112,7 +112,7 @@ fn test_spec_sections_objects_and_hashes_should_be_pushed_onto_context_stack() {
 //                 .insert_int("five", 5)
 //         });
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("{{#a}}
+//     data.render("{{#a}}
 //                            {{one}}
 //                            {{#b}}
 //                            {{one}}{{two}}{{one}}
@@ -166,7 +166,7 @@ fn test_spec_sections_list_items_are_iterated() {
                 )
         );
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{#list}}{{item}}{{/list}}", data, &mut rv).unwrap();
+    data.render("{{#list}}{{item}}{{/list}}", &mut rv).unwrap();
 
     assert_eq!("123".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -181,7 +181,7 @@ fn test_spec_sections_empty_lists_behave_like_falsy_values() {
     let data = HashBuilder::new()
         .insert("list", VecBuilder::new());
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("{{#list}}Yay lists!{{/list}}", data, &mut rv).unwrap();
+    data.render("{{#list}}Yay lists!{{/list}}", &mut rv).unwrap();
 
     assert_eq!("".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -207,7 +207,7 @@ fn test_spec_sections_empty_lists_behave_like_falsy_values() {
 //         .insert_bool("bool", true)
 //         .insert("two", "second");
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("{{#bool}}
+//     data.render("{{#bool}}
 //                            * first
 //                            {{/bool}}
 //                            * {{two}}
@@ -235,7 +235,7 @@ fn test_spec_sections_nested_truthy_contents_render() {
     let data = HashBuilder::new()
         .insert("bool", true);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("| A {{#bool}}B {{#bool}}C{{/bool}} D{{/bool}} E |", data, &mut rv).unwrap();
+    data.render("| A {{#bool}}B {{#bool}}C{{/bool}} D{{/bool}} E |", &mut rv).unwrap();
 
     assert_eq!("| A B C D E |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -250,7 +250,7 @@ fn test_spec_sections_nested_falsy_contents_do_not_render() {
     let data = HashBuilder::new()
         .insert("bool", false);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("| A {{#bool}}B {{#bool}}C{{/bool}} D{{/bool}} E |", data, &mut rv).unwrap();
+    data.render("| A {{#bool}}B {{#bool}}C{{/bool}} D{{/bool}} E |", &mut rv).unwrap();
 
     assert_eq!("| A  E |".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -264,7 +264,7 @@ fn test_spec_sections_nested_falsy_contents_do_not_render() {
 fn test_spec_sections_failed_context_lookups_are_falsy() {
     let data = HashBuilder::new();
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("[{{#missing}}Found key 'missing'!{{/missing}}]", data, &mut rv).unwrap();
+    data.render("[{{#missing}}Found key 'missing'!{{/missing}}]", &mut rv).unwrap();
 
     assert_eq!("[]".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -287,7 +287,7 @@ fn test_spec_sections_failed_context_lookups_are_falsy() {
 //                 .push_string("e")
 //         });
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("{{#list}}({{.}}){{/list}}", data, &mut rv).unwrap();
+//     data.render("{{#list}}({{.}}){{/list}}", &mut rv).unwrap();
 
 //     assert_eq!("(a)(b)(c)(d)(e)".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -310,7 +310,7 @@ fn test_spec_sections_failed_context_lookups_are_falsy() {
 //                 .push_int(5)
 //         });
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("{{#list}}({{.}}){{/list}}", data, &mut rv).unwrap();
+//     data.render("{{#list}}({{.}}){{/list}}", &mut rv).unwrap();
 
 //     assert_eq!("(1)(2)(3)(4)(5)".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -333,7 +333,7 @@ fn test_spec_sections_failed_context_lookups_are_falsy() {
 //                 .push_float(5.50)
 //         });
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("{{#list}}({{.}}){{/list}}", data, &mut rv).unwrap();
+//     data.render("{{#list}}({{.}}){{/list}}", &mut rv).unwrap();
 
 //     assert_eq!("(1.1)(2.2)(3.3)(4.4)(5.5)".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -354,7 +354,7 @@ fn test_spec_sections_failed_context_lookups_are_falsy() {
 //             })
 //         });
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("'{{#a.b.c}}Here{{/a.b.c}}' == 'Here'", data, &mut rv).unwrap();
+//     data.render("'{{#a.b.c}}Here{{/a.b.c}}' == 'Here'", &mut rv).unwrap();
 
 //     assert_eq!("'Here' == 'Here'".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -373,7 +373,7 @@ fn test_spec_sections_falsy_dotted_names_are_not_valid_section_tags() {
             )
         );
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("'{{#a.b.c}}Here{{/a.b.c}}' == ''", data, &mut rv).unwrap();
+    data.render("'{{#a.b.c}}Here{{/a.b.c}}' == ''", &mut rv).unwrap();
 
     assert_eq!("'' == ''".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -388,7 +388,7 @@ fn test_spec_sections_unresolved_dotted_names_are_not_valid_section_tags() {
     let data = HashBuilder::new()
         .insert("a", HashBuilder::new());
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("'{{#a.b.c}}Here{{/a.b.c}}' == ''", data, &mut rv).unwrap();
+    data.render("'{{#a.b.c}}Here{{/a.b.c}}' == ''", &mut rv).unwrap();
 
     assert_eq!("'' == ''".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -403,7 +403,7 @@ fn test_spec_sections_do_not_alter_surrounding_whitespace() {
     let data = HashBuilder::new()
         .insert("boolean", true);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text(" | {{#boolean}}\t|\t{{/boolean}} | \n", data, &mut rv).unwrap();
+    data.render(" | {{#boolean}}\t|\t{{/boolean}} | \n", &mut rv).unwrap();
 
     assert_eq!(" | \t|\t | \n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -418,7 +418,7 @@ fn test_spec_sections_do_not_alter_surrounding_whitespace() {
 //     let data = HashBuilder::new()
 //         .insert_bool("boolean", true);
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text(" | {{#boolean}} {{! Important Whitespace }}\n {{/boolean}} | \n", data, &mut rv).unwrap();
+//     data.render(" | {{#boolean}} {{! Important Whitespace }}\n {{/boolean}} | \n", &mut rv).unwrap();
 
 //     assert_eq!(" |  \n  | \n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -433,7 +433,7 @@ fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace()
     let data = HashBuilder::new()
         .insert("boolean", true);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text(" {{#boolean}}YES{{/boolean}}\n {{#boolean}}GOOD{{/boolean}}\n", data, &mut rv).unwrap();
+    data.render(" {{#boolean}}YES{{/boolean}}\n {{#boolean}}GOOD{{/boolean}}\n", &mut rv).unwrap();
 
     assert_eq!(" YES\n GOOD\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }
@@ -456,7 +456,7 @@ fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace()
 //     let data = HashBuilder::new()
 //         .insert("boolean", true);
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("|
+//     data.render("|
 //                            | This Is
 //                            {{#boolean}}
 //                            |
@@ -492,7 +492,7 @@ fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace()
 //     let data = HashBuilder::new()
 //         .insert_bool("boolean", true);
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("|
+//     data.render("|
 //                            | This Is
 //                              {{#boolean}}
 //                            |
@@ -519,7 +519,7 @@ fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace()
 //     let data = HashBuilder::new()
 //         .insert_bool("boolean", true);
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("|\r\n{{#boolean}}\r\n{{/boolean}}\r\n|", data, &mut rv).unwrap();
+//     data.render("|\r\n{{#boolean}}\r\n{{/boolean}}\r\n|", &mut rv).unwrap();
 
 //     assert_eq!("|\r\n|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -534,7 +534,7 @@ fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace()
 //     let data = HashBuilder::new()
 //         .insert_bool("boolean", true);
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("  {{#boolean}}\n#{{/boolean}}\n/", data, &mut rv).unwrap();
+//     data.render("  {{#boolean}}\n#{{/boolean}}\n/", &mut rv).unwrap();
 
 //     assert_eq!("#\n/".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -549,7 +549,7 @@ fn test_spec_sections_single_line_sections_do_not_alter_surrounding_whitespace()
 //     let data = HashBuilder::new()
 //         .insert_bool("boolean", true);
 //     let mut rv = Cursor::new(Vec::new());
-//     rustache::render_text("#{{#boolean}}\n/\n  {{/boolean}}", data, &mut rv).unwrap();
+//     data.render("#{{#boolean}}\n/\n  {{/boolean}}", &mut rv).unwrap();
 
 //     assert_eq!("#\n/\n".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 // }
@@ -564,7 +564,7 @@ fn test_spec_sections_superfluous_tag_whitespace_is_ignored() {
     let data = HashBuilder::new()
         .insert("boolean", true);
     let mut rv = Cursor::new(Vec::new());
-    rustache::render_text("|{{# boolean }}={{/ boolean }}|", data, &mut rv).unwrap();
+    data.render("|{{# boolean }}={{/ boolean }}|", &mut rv).unwrap();
 
     assert_eq!("|=|".to_string(), String::from_utf8(rv.into_inner()).unwrap());
 }


### PR DESCRIPTION
This changes the API have `render` take the cursor instead of having it allocate one and drop `render_text` and `render_file` in favor of the `Render` trait implemented on a number of types.