### PR TITLE
bump minimum version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rust:
 - nightly
 - beta
 - stable
-- 1.3.0
+- 1.4.0
 matrix:
   allow_failures:
   - rust: nightly


### PR DESCRIPTION
Bump the minimum supported Rust version to be able to use iterators nicely.