### PR TITLE
Use error-chain for generating Error boilerplate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rust:
 - nightly
 - beta
 - stable
-- 1.4.0
+- 1.8.0
 matrix:
   allow_failures:
   - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,6 @@ name = "rustache"
 path = "src/lib.rs"
 
 [dependencies]
+error-chain = "^0.5"
 regex = "^0.1"
 rustc-serialize = "^0.3"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,32 @@
+#![allow(missing_docs)]
+use rustc_serialize::json;
+use std::io;
+
+error_chain! {
+
+    foreign_links {
+        json::BuilderError, Json;
+    }
+
+    errors {
+        StreamWriteError(err: io::Error, msg: String) {
+            description("error writing to a stream")
+            display("{}: {}", err, msg)
+        }
+
+        FileReadError(err: io::Error, filename: String) {
+            description("error reading from a file")
+            display("{}: {}", err, filename)
+        }
+
+        UnexpectedDataType(data: String) {
+            description("unexpected data type")
+            display("{}", data)
+        }
+
+        UnexpectedNodeType(t: String) {
+            description("unexpected node type")
+            display("{}", t)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 #![deny(missing_docs)]
+#![recursion_limit = "1024"]
 
 //! The main crate for the Rustache library.
 //!
 //! Rustache is a flexible template engine for Rust.
-
+#[macro_use]
+extern crate error_chain;
 extern crate rustc_serialize;
 
 use std::fmt;
@@ -17,20 +19,7 @@ pub use build::{HashBuilder, VecBuilder};
 pub use rustache::Render;
 
 /// Alias for Result<T, `RustacheError`>
-pub type RustacheResult<T> = Result<T, RustacheError>;
-
-/// Enum to handle errors from the Rustache library.
-#[derive(Debug)]
-pub enum RustacheError {
-    // ParserErrorType(ParserError),
-    // CompilerErrorType(CompilerError),
-    /// Error parsing JSON data
-    JsonError(String),
-    /// Error opening or reading a file
-    FileError(String),
-    /// Generic enum value for any errors from the template module.
-    TemplateErrorType(template::TemplateError),
-}
+pub use errors::*;
 
 // Represents the possible types that passed in data may take on
 #[doc(hidden)]
@@ -126,6 +115,7 @@ impl<'a> fmt::Debug for Data<'a> {
 }
 
 // Internal Modules
+mod errors;
 mod rustache;
 mod compiler;
 mod parser;


### PR DESCRIPTION
Use the error-chain machinery for generating the Error boilerplate in a standard fashion. This branch ceases the use of `RustacheResult` and `RustacheError` in favor of redefining the standard names. Additionally, it captures the actual errors behind the stream and file errors instead of just capturing the display strings. Finally, it flattens the error structure to a single level instead of having the template errors as their own type.