### PR TITLE
Remove rust 1.8 from the CI targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ rust:
 - nightly
 - beta
 - stable
-- 1.8.0
 matrix:
   allow_failures:
   - rust: nightly


### PR DESCRIPTION
rust 1.8 is two years old and makes the automatic build fail